### PR TITLE
Fixed the Parse().initialize's return value

### DIFF
--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -135,7 +135,7 @@ class Parse {
 
     _hasBeenInitialized = true;
 
-    return Parse();
+    return this;
   }
 
   bool hasParseBeenInitialized() => _hasBeenInitialized;


### PR DESCRIPTION
Parse().initialize returns a new instantiation of the Parse class, but it should return the current instance.