### PR TITLE
Specifying return type of get<T> as T instead of dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+## 1.0.26
+
 ## 1.0.25
+Update dependencies
 
 ## 1.0.24
 Fixed lint

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Want to get involved? Join our Slack channel and help out! (http://flutter-parse
 To install, either add to your pubspec.yaml
 ```yml
 dependencies:  
-    parse_server_sdk: ^1.0.25
+    parse_server_sdk: ^1.0.26
 ```
 or clone this repository and add to your project. As this is an early development with multiple contributors, it is probably best to download/clone and keep updating as an when a new feature is added.
 
@@ -330,7 +330,7 @@ You’ll get the LiveQuery events through this subscription.
 The first time you call subscribe, we’ll try to open the WebSocket connection to the LiveQuery server for you.
 
 ```dart
-await liveQuery.subscribe(query);
+Subscription subscription = await liveQuery.client.subscribe(query);
 ```
 
 __Event Handling__
@@ -340,7 +340,7 @@ __Create event__
 When a new ParseObject is created and it fulfills the QueryBuilder you subscribe, you’ll get this event. 
 The object is the ParseObject which was created.
 ```dart
-liveQuery.on(LiveQueryEvent.create, (value) {
+subscription.on(LiveQueryEvent.create, (value) {
     print('*** CREATE ***: ${DateTime.now().toString()}\n $value ');
     print((value as ParseObject).objectId);
     print((value as ParseObject).updatedAt);
@@ -356,7 +356,7 @@ When an existing ParseObject which fulfills the QueryBuilder you subscribe is up
 QueryBuilder before and after changes), you’ll get this event. 
 The object is the ParseObject which was updated. Its content is the latest value of the ParseObject.
 ```dart
-liveQuery.on(LiveQueryEvent.update, (value) {
+subscription.on(LiveQueryEvent.update, (value) {
     print('*** UPDATE ***: ${DateTime.now().toString()}\n $value ');
     print((value as ParseObject).objectId);
     print((value as ParseObject).updatedAt);
@@ -372,7 +372,7 @@ When an existing ParseObject’s old value does not fulfill the QueryBuilder but
 you’ll get this event. The object is the ParseObject which enters the QueryBuilder. 
 Its content is the latest value of the ParseObject.
 ```dart
-liveQuery.on(LiveQueryEvent.enter, (value) {
+subscription.on(LiveQueryEvent.enter, (value) {
     print('*** ENTER ***: ${DateTime.now().toString()}\n $value ');
     print((value as ParseObject).objectId);
     print((value as ParseObject).updatedAt);
@@ -388,7 +388,7 @@ When an existing ParseObject’s old value fulfills the QueryBuilder but its new
 you’ll get this event. The object is the ParseObject which leaves the QueryBuilder. 
 Its content is the latest value of the ParseObject.
 ```dart
-liveQuery.on(LiveQueryEvent.leave, (value) {
+subscription.on(LiveQueryEvent.leave, (value) {
     print('*** LEAVE ***: ${DateTime.now().toString()}\n $value ');
     print((value as ParseObject).objectId);
     print((value as ParseObject).updatedAt);
@@ -403,7 +403,7 @@ __Delete event__
 When an existing ParseObject which fulfills the QueryBuilder is deleted, you’ll get this event. 
 The object is the ParseObject which is deleted
 ```dart
-liveQuery.on(LiveQueryEvent.delete, (value) {
+subscription.on(LiveQueryEvent.delete, (value) {
     print('*** DELETE ***: ${DateTime.now().toString()}\n $value ');
     print((value as ParseObject).objectId);
     print((value as ParseObject).updatedAt);
@@ -420,7 +420,7 @@ After that, you won’t get any events from the subscription object and will clo
 LiveQuery server.
 
 ```dart
-await liveQuery.unSubscribe();
+liveQuery.client.unSubscribe(subscription);
 ```
 
 ## Users

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -135,7 +135,7 @@ class Parse {
 
     _hasBeenInitialized = true;
 
-    return Parse();
+    return this;
   }
 
   bool hasParseBeenInitialized() => _hasBeenInitialized;

--- a/lib/src/base/parse_constants.dart
+++ b/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '1.0.25';
+const String keySdkVersion = '1.0.26';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/lib/src/objects/parse_base.dart
+++ b/lib/src/objects/parse_base.dart
@@ -220,7 +220,7 @@ abstract class ParseBase {
   /// Returns null or [defaultValue] if provided. To get an int, call
   /// getType<int> and an int will be returned, null, or a defaultValue if
   /// provided
-  dynamic get<T>(String key, {T defaultValue}) {
+  T get<T>(String key, {T defaultValue}) {
     if (_getObjectData().containsKey(key)) {
       if (T != null && _getObjectData()[key] is T) {
         final T data = _getObjectData()[key];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 1.0.25
+version: 1.0.26
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 author: PhillWiggins <phill.wiggins@gmail.com>
 


### PR DESCRIPTION
Small change, but I think it's a good practice to return a concrete type instead of dynamic when we can.

Additionally, for developers who have `implicit-casts` set to `false` in their analysys_options.yaml, from this point on they won't have to write code like this:
`String name = get<String>('name') as String;`
but instead will be able to do just:
`String name = get<String>('name');`

Thanks for making this package btw! :) 