### PR TITLE
added QueryBuilder.copy(QueryBuilder<T> query)

### DIFF
--- a/lib/src/network/parse_query.dart
+++ b/lib/src/network/parse_query.dart
@@ -17,6 +17,16 @@ class QueryBuilder<T extends ParseObject> {
     }
   }
 
+  QueryBuilder.copy(QueryBuilder<T> query) {
+    object = query.object;
+    queries = query.queries
+        .map((MapEntry<String, dynamic> entry) =>
+            MapEntry<String, dynamic>(entry.key, entry.value.toString()))
+        .toList();
+    query.limiters.forEach((String key, dynamic value) =>
+        limiters.putIfAbsent(key, () => value.toString()));
+  }
+
   static const String _NO_OPERATOR_NEEDED = 'NO_OP';
   static const String _SINGLE_QUERY = 'SINGLE_QUERY';
 


### PR DESCRIPTION
I could not find any way to copy a QueryBuilder.

So I added a constructor that takes an QueryBuilder as a base.
This is a deep copy.
Tested only with basic queries.

#319 