### PR TITLE
Fix: LiveList reorder on update(#341)

### DIFF
--- a/lib/src/utils/parse_live_list.dart
+++ b/lib/src/utils/parse_live_list.dart
@@ -181,7 +181,7 @@ class ParseLiveList<T extends ParseObject> {
           _list.removeAt(i).dispose();
           _eventStreamController.sink.add(ParseLiveListDeleteEvent<T>(
               i, object?.clone(object?.toJson(full: true))));
-          _objectAdded(object);
+          _objectAdded(object?.clone(object?.toJson(full: true)));
         }
         break;
       }


### PR DESCRIPTION
Fixes #341 

It seems like `subscription.on(LiveQueryEvent.update` reuses an existing object.