### PR TITLE
RegisterSubClass and smaler changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ class DietPlan extends ParseObject implements ParseCloneable {
   
 ```
 
+When receiving an `ParseObject` from the SDK, you can often provide an instance of your custom object as an copy object.
+To always use your custom object class, you can register your subclass at the initialization of the SDK.
+```dart
+Parse().initialize(
+   ...,
+   registeredSubClassMap: <String, ParseObjectConstructor>{
+     'Diet_Plans': () => DietPlan(),
+   },
+   parseUserConstructor: (username, password, emailAddress, {client, debug, sessionToken}) => CustomParseUser(username, password, emailAddress),
+);
+```
+Additionally you can register `SubClasses` after the initialization of the SDK.
+```dart
+ParseCoreData().registerSubClass('Diet_Plans', () => DietPlan());
+ParseCoreData().registerUserSubClass((username, password, emailAddress, {client, debug, sessionToken}) => CustomParseUser(username, password, emailAddress));
+```
+Providing a `ParseObject` as described above should still work, even if you have registered a different `SubClass.
+
 ## Add new values to objects
 To add a variable to an object call and retrieve it, call
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Additionally you can register `SubClasses` after the initialization of the SDK.
 ParseCoreData().registerSubClass('Diet_Plans', () => DietPlan());
 ParseCoreData().registerUserSubClass((username, password, emailAddress, {client, debug, sessionToken}) => CustomParseUser(username, password, emailAddress));
 ```
-Providing a `ParseObject` as described above should still work, even if you have registered a different `SubClass.
+Providing a `ParseObject` as described above should still work, even if you have registered a different `SubClass`.
 
 ## Add new values to objects
 To add a variable to an object call and retrieve it, call

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -23,6 +23,7 @@ export 'src/network/parse_live_query.dart'
 if (dart.library.js) 'src/network/parse_live_query_web.dart';
 export 'src/utils/parse_live_list.dart';
 
+part 'package:parse_server_sdk/src/data/parse_subclass_handler.dart';
 part 'package:parse_server_sdk/src/objects/response/parse_error_response.dart';
 
 part 'package:parse_server_sdk/src/objects/response/parse_exception_response.dart';

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -112,28 +112,38 @@ class Parse {
   //        debug: true,
   //        liveQuery: true);
   // ```
-  Future<Parse> initialize(String appId, String serverUrl,
-      {bool debug = false,
-      String appName = '',
-      String liveQueryUrl,
-      String clientKey,
-      String masterKey,
-      String sessionId,
-      bool autoSendSessionId,
-        SecurityContext securityContext,
-        CoreStore coreStore}) async {
+  Future<Parse> initialize(
+    String appId,
+    String serverUrl, {
+    bool debug = false,
+    String appName = '',
+    String liveQueryUrl,
+    String clientKey,
+    String masterKey,
+    String sessionId,
+    bool autoSendSessionId,
+    SecurityContext securityContext,
+    CoreStore coreStore,
+    Map<String, ParseObjectConstructor> registeredSubClassMap,
+    ParseUserConstructor parseUserConstructor,
+  }) async {
     final String url = removeTrailingSlash(serverUrl);
 
-    await ParseCoreData.init(appId, url,
-        debug: debug,
-        appName: appName,
-        liveQueryUrl: liveQueryUrl,
-        masterKey: masterKey,
-        clientKey: clientKey,
-        sessionId: sessionId,
-        autoSendSessionId: autoSendSessionId,
-        securityContext: securityContext,
-        store: coreStore);
+    await ParseCoreData.init(
+      appId,
+      url,
+      debug: debug,
+      appName: appName,
+      liveQueryUrl: liveQueryUrl,
+      masterKey: masterKey,
+      clientKey: clientKey,
+      sessionId: sessionId,
+      autoSendSessionId: autoSendSessionId,
+      securityContext: securityContext,
+      store: coreStore,
+      registeredSubClassMap: registeredSubClassMap,
+      parseUserConstructor: parseUserConstructor,
+    );
 
     _hasBeenInitialized = true;
 

--- a/lib/src/data/parse_core_data.dart
+++ b/lib/src/data/parse_core_data.dart
@@ -23,7 +23,9 @@ class ParseCoreData {
       String sessionId,
       bool autoSendSessionId,
       SecurityContext securityContext,
-      CoreStore store}) async {
+      CoreStore store,
+      Map<String, ParseObjectConstructor> registeredSubClassMap,
+      ParseUserConstructor parseUserConstructor}) async {
     _instance = ParseCoreData._init(appId, serverUrl);
 
     _instance.storage ??=
@@ -54,7 +56,10 @@ class ParseCoreData {
       _instance.securityContext = securityContext;
     }
 
-    _instance._subClassHandler = ParseSubClassHandler();
+    _instance._subClassHandler = ParseSubClassHandler(
+      registeredSubClassMap: registeredSubClassMap,
+      parseUserConstructor: parseUserConstructor,
+    );
   }
 
   String appName;
@@ -70,7 +75,8 @@ class ParseCoreData {
   CoreStore storage;
   ParseSubClassHandler _subClassHandler;
 
-  void registerSubClass(String className, ObjectConstructor objectConstructor) {
+  void registerSubClass(
+      String className, ParseObjectConstructor objectConstructor) {
     _subClassHandler.registerSubClass(className, objectConstructor);
   }
 

--- a/lib/src/data/parse_core_data.dart
+++ b/lib/src/data/parse_core_data.dart
@@ -22,8 +22,8 @@ class ParseCoreData {
       String clientKey,
       String sessionId,
       bool autoSendSessionId,
-        SecurityContext securityContext,
-        CoreStore store}) async {
+      SecurityContext securityContext,
+      CoreStore store}) async {
     _instance = ParseCoreData._init(appId, serverUrl);
 
     _instance.storage ??=
@@ -74,8 +74,19 @@ class ParseCoreData {
     _subClassHandler.registerSubClass(className, objectConstructor);
   }
 
+  void registerUserSubClass(ParseUserConstructor parseUserConstructor) {
+    _subClassHandler.registerUserSubClass(parseUserConstructor);
+  }
+
   ParseObject createObject(String classname) {
     return _subClassHandler.createObject(classname);
+  }
+
+  ParseUser createParseUser(
+      String username, String password, String emailAddress,
+      {String sessionToken, bool debug, ParseHTTPClient client}) {
+    return _subClassHandler.createParseUser(username, password, emailAddress,
+        sessionToken: sessionToken, debug: debug, client: client);
   }
 
   /// Sets the current sessionId.

--- a/lib/src/data/parse_core_data.dart
+++ b/lib/src/data/parse_core_data.dart
@@ -53,6 +53,8 @@ class ParseCoreData {
     if (securityContext != null) {
       _instance.securityContext = securityContext;
     }
+
+    _instance._subClassHandler = ParseSubClassHandler();
   }
 
   String appName;
@@ -66,6 +68,15 @@ class ParseCoreData {
   SecurityContext securityContext;
   bool debug;
   CoreStore storage;
+  ParseSubClassHandler _subClassHandler;
+
+  void registerSubClass(String className, ObjectConstructor objectConstructor) {
+    _subClassHandler.registerSubClass(className, objectConstructor);
+  }
+
+  ParseObject createObject(String classname) {
+    return _subClassHandler.createObject(classname);
+  }
 
   /// Sets the current sessionId.
   ///

--- a/lib/src/data/parse_subclass_handler.dart
+++ b/lib/src/data/parse_subclass_handler.dart
@@ -1,18 +1,39 @@
 part of flutter_parse_sdk;
 
 typedef ObjectConstructor = ParseObject Function();
+typedef ParseUserConstructor = ParseUser Function(
+    String username, String password, String emailAddress,
+    {String sessionToken, bool debug, ParseHTTPClient client});
 
 class ParseSubClassHandler {
   final Map<String, ObjectConstructor> _subClassMap =
       Map<String, ObjectConstructor>();
+  ParseUserConstructor _parseUserConstructor;
 
   void registerSubClass(String className, ObjectConstructor objectConstructor) {
-    _subClassMap.putIfAbsent(className, () => objectConstructor);
+    if (className != keyClassUser &&
+        className != keyClassInstallation &&
+        className != keyClassSession)
+      _subClassMap.putIfAbsent(className, () => objectConstructor);
+  }
+
+  void registerUserSubClass(ParseUserConstructor parseUserConstructor) {
+    _parseUserConstructor ??= parseUserConstructor;
   }
 
   ParseObject createObject(String classname) {
+    if (classname == keyClassUser) return createParseUser(null, null, null);
     if (_subClassMap.containsKey(classname)) return _subClassMap[classname]();
-    if (classname == '_User') return ParseUser._getEmptyUser();
     return ParseObject(classname);
+  }
+
+  ParseUser createParseUser(
+      String username, String password, String emailAddress,
+      {String sessionToken, bool debug, ParseHTTPClient client}) {
+    return _parseUserConstructor != null
+        ? _parseUserConstructor(username, password, emailAddress,
+            sessionToken: sessionToken, debug: debug, client: client)
+        : ParseUser(username, password, emailAddress,
+            sessionToken: sessionToken, debug: debug, client: client);
   }
 }

--- a/lib/src/data/parse_subclass_handler.dart
+++ b/lib/src/data/parse_subclass_handler.dart
@@ -1,0 +1,11 @@
+part of flutter_parse_sdk;
+
+class ParseSubClassHandler {
+  final Map<String, ParseObject> _subClassMap = Map<String, ParseObject>();
+
+  void registerSubClass(String className, ParseObject cloneObject) {
+    _subClassMap.putIfAbsent(className, () => cloneObject);
+  }
+
+  void
+}

--- a/lib/src/data/parse_subclass_handler.dart
+++ b/lib/src/data/parse_subclass_handler.dart
@@ -1,16 +1,23 @@
 part of flutter_parse_sdk;
 
-typedef ObjectConstructor = ParseObject Function();
+typedef ParseObjectConstructor = ParseObject Function();
 typedef ParseUserConstructor = ParseUser Function(
     String username, String password, String emailAddress,
     {String sessionToken, bool debug, ParseHTTPClient client});
 
 class ParseSubClassHandler {
-  final Map<String, ObjectConstructor> _subClassMap =
-      Map<String, ObjectConstructor>();
+
+  ParseSubClassHandler({Map<String, ParseObjectConstructor> registeredSubClassMap,
+    ParseUserConstructor parseUserConstructor}){
+    _subClassMap = registeredSubClassMap ?? Map<String, ParseObjectConstructor>();
+    _parseUserConstructor = parseUserConstructor;
+  }
+
+  Map<String, ParseObjectConstructor> _subClassMap;
   ParseUserConstructor _parseUserConstructor;
 
-  void registerSubClass(String className, ObjectConstructor objectConstructor) {
+  void registerSubClass(
+      String className, ParseObjectConstructor objectConstructor) {
     if (className != keyClassUser &&
         className != keyClassInstallation &&
         className != keyClassSession)

--- a/lib/src/data/parse_subclass_handler.dart
+++ b/lib/src/data/parse_subclass_handler.dart
@@ -1,11 +1,18 @@
 part of flutter_parse_sdk;
 
-class ParseSubClassHandler {
-  final Map<String, ParseObject> _subClassMap = Map<String, ParseObject>();
+typedef ObjectConstructor = ParseObject Function();
 
-  void registerSubClass(String className, ParseObject cloneObject) {
-    _subClassMap.putIfAbsent(className, () => cloneObject);
+class ParseSubClassHandler {
+  final Map<String, ObjectConstructor> _subClassMap =
+      Map<String, ObjectConstructor>();
+
+  void registerSubClass(String className, ObjectConstructor objectConstructor) {
+    _subClassMap.putIfAbsent(className, () => objectConstructor);
   }
 
-  void
+  ParseObject createObject(String classname) {
+    if (_subClassMap.containsKey(classname)) return _subClassMap[classname]();
+    if (classname == '_User') return ParseUser._getEmptyUser();
+    return ParseObject(classname);
+  }
 }

--- a/lib/src/network/parse_live_query.dart
+++ b/lib/src/network/parse_live_query.dart
@@ -408,13 +408,15 @@ class Client {
       if (actionData.containsKey('object')) {
         final Map<String, dynamic> map = actionData['object'];
         final String className = map['className'];
-        if (className == '_User') {
+        if (className == keyClassUser) {
           subscription.eventCallbacks[actionData['op']](
-              (subscription.copyObject ?? ParseUser(null, null, null))
+              (subscription.copyObject ??
+                      ParseCoreData.instance.createParseUser(null, null, null))
                   .fromJson(map));
         } else {
           subscription.eventCallbacks[actionData['op']](
-              (subscription.copyObject ?? ParseObject(className))
+              (subscription.copyObject ??
+                      ParseCoreData.instance.createObject(className))
                   .fromJson(map));
         }
       } else {

--- a/lib/src/network/parse_live_query_web.dart
+++ b/lib/src/network/parse_live_query_web.dart
@@ -406,13 +406,15 @@ class Client {
       if (actionData.containsKey('object')) {
         final Map<String, dynamic> map = actionData['object'];
         final String className = map['className'];
-        if (className == '_User') {
+        if (className == keyClassUser) {
           subscription.eventCallbacks[actionData['op']](
-              (subscription.copyObject ?? ParseUser(null, null, null))
+              (subscription.copyObject ??
+                      ParseCoreData.instance.createParseUser(null, null, null))
                   .fromJson(map));
         } else {
           subscription.eventCallbacks[actionData['op']](
-              (subscription.copyObject ?? ParseObject(className))
+              (subscription.copyObject ??
+                      ParseCoreData.instance.createObject(className))
                   .fromJson(map));
         }
       } else {

--- a/lib/src/network/parse_query.dart
+++ b/lib/src/network/parse_query.dart
@@ -5,6 +5,9 @@ class QueryBuilder<T extends ParseObject> {
   /// Class to create complex queries
   QueryBuilder(this.object) : super();
 
+  QueryBuilder.name(String classname)
+      : this(ParseCoreData.instance.createObject(classname));
+
   QueryBuilder.or(this.object, List<QueryBuilder<T>> list) {
     if (list != null) {
       String query = '"\$or":[';

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -328,6 +328,19 @@ class ParseUser extends ParseObject implements ParseCloneable {
     }
   }
 
+  @override
+  Future<ParseResponse> update() async {
+    if (objectId == null) {
+      return await signUp();
+    } else {
+      final ParseResponse response = await super.update();
+      if (response.success) {
+        await _onResponseSuccess();
+      }
+      return response;
+    }
+  }
+
   Future<void> _onResponseSuccess() async {
     await saveInStorage(keyParseStoreUser);
   }

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -76,7 +76,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   static ParseUser createUser(
       [String username, String password, String emailAddress]) {
-    return ParseUser(username, password, emailAddress);
+    return ParseCoreData.instance
+        .createParseUser(username, password, emailAddress);
   }
 
   /// Gets the current user from the server
@@ -412,7 +413,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
     }
   }
 
-  static ParseUser _getEmptyUser() => ParseUser(null, null, null);
+  static ParseUser _getEmptyUser() =>
+      ParseCoreData.instance.createParseUser(null, null, null);
 
   static Future<String> _getInstallationId() async {
     final ParseInstallation parseInstallation =

--- a/lib/src/storage/core_store_sem_impl.dart
+++ b/lib/src/storage/core_store_sem_impl.dart
@@ -12,7 +12,7 @@ class CoreStoreSembastImp implements CoreStore {
       factory ??= databaseFactoryIo;
       final SembastCodec codec = getXXTeaSembastCodec(password: password);
       String dbDirectory = '';
-      if (Platform.isIOS || Platform.isAndroid)
+      if (Platform.isIOS || Platform.isAndroid || Platform.isMacOS)
         dbDirectory = (await getApplicationDocumentsDirectory()).path;
       final String dbPath = path.join('$dbDirectory/parse', 'parse.db');
       final Database db = await factory.openDatabase(dbPath, codec: codec);

--- a/lib/src/utils/parse_decoder.dart
+++ b/lib/src/utils/parse_decoder.dart
@@ -58,17 +58,9 @@ dynamic parseDecode(dynamic value) {
         final String val = map['base64'];
         return base64.decode(val);
       case 'Pointer':
-        final String className = map['className'];
-        if (className == '_User') {
-          return ParseUser._getEmptyUser().fromJson(map);
-        }
-        return ParseObject(className).fromJson(map);
       case 'Object':
         final String className = map['className'];
-        if (className == '_User') {
-          return ParseUser._getEmptyUser().fromJson(map);
-        }
-        return ParseObject(className).fromJson(map);
+        return ParseCoreData.instance.createObject(className).fromJson(map);
       case 'File':
         return ParseFile(null, url: map['url'], name: map['name'])
             .fromJson(map);
@@ -86,15 +78,15 @@ dynamic parseDecode(dynamic value) {
   /// Decoding from locally cached JSON
   if (map.containsKey('className')) {
     switch (map['className']) {
-      case '_User':
-        return ParseUser._getEmptyUser().fromJson(map);
       case 'GeoPoint':
         final num latitude = map['latitude'] ?? 0.0;
         final num longitude = map['longitude'] ?? 0.0;
         return ParseGeoPoint(
             latitude: latitude.toDouble(), longitude: longitude.toDouble());
       default:
-        return ParseObject(map['className']).fromJson(map);
+        return ParseCoreData.instance
+            .createObject(map['className'])
+            .fromJson(map);
     }
   }
 


### PR DESCRIPTION
As described in https://github.com/parse-community/Parse-SDK-Flutter/issues/350#issuecomment-614071136, I have now worked with this RegisterSubClass feature for a while.
While testing, I haven't encountered a single bug.
I think, this feature is ready for merging.

For more details about RegisterSubClass, have a lock into the new README.

This PR also contains a Fix for a Bug, where CoreStore would not work when using the sembast implementation in an macos app.

And a fix for #364 / #256.

I have created one PR for this three changes. If this is a problem, I can create separated ones as well.