### PR TITLE
[Fix] InstallationId storage and User login

### DIFF
--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -153,6 +153,8 @@ class ParseInstallation extends ParseObject {
     final ParseInstallation installation = ParseInstallation();
     installation._installationId = _currentInstallationId;
     await installation._updateInstallation();
+    await ParseCoreData().getStore().setString(keyParseStoreInstallation,
+        json.encode(installation.toJson(full: true)));
     return installation;
   }
 

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -118,11 +118,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
     try {
       final Uri url = getSanitisedUri(_client, '$keyEndPointUserName');
       final Response response = await _client.get(url, headers: headers);
-      return await _handleResponse(this, response,
-          ParseApiRQ.currentUser, _debug, parseClassName);
+      return await _handleResponse(
+          this, response, ParseApiRQ.currentUser, _debug, parseClassName);
     } on Exception catch (e) {
-      return handleException(
-          e, ParseApiRQ.currentUser, _debug, parseClassName);
+      return handleException(e, ParseApiRQ.currentUser, _debug, parseClassName);
     }
   }
 
@@ -178,13 +177,14 @@ class ParseUser extends ParseObject implements ParseCloneable {
         keyVarUsername: username,
         keyVarPassword: password
       };
-
+      final String installationId = await _getInstallationId();
       final Uri url = getSanitisedUri(_client, '$keyEndPointLogin',
           queryParams: queryParams);
       _saveChanges();
       final Response response =
           await _client.get(url, headers: <String, String>{
         keyHeaderRevocableSession: '1',
+        if (installationId != null) keyHeaderInstallationId: installationId,
       });
 
       return await _handleResponse(


### PR DESCRIPTION
Related issue: https://github.com/parse-community/Parse-SDK-Flutter/issues/373
+ Save ParseInstallation in ParseCoreData after creating new instance.
+ ParseUser.login() now send installationId (this way, no new session is created at every login event)