### PR TITLE
ParseLiveElement

### DIFF
--- a/lib/src/utils/parse_live_list.dart
+++ b/lib/src/utils/parse_live_list.dart
@@ -451,7 +451,7 @@ class ParseLiveElement<T extends ParseObject> extends ParseLiveListElement<T> {
             updatedSubItems:
                 ParseLiveList._toIncludeMap(includeObject ?? <String>[])) {
     _includes = ParseLiveList._toIncludeMap(includeObject ?? <String>[]);
-    queryBuilder = QueryBuilder<T>(object)
+    queryBuilder = QueryBuilder<T>(object.clone(null))
       ..includeObject(includeObject)
       ..whereEqualTo(keyVarObjectId, object.objectId);
     _init(object, loaded: loaded, includeObject: includeObject);
@@ -470,16 +470,14 @@ class ParseLiveElement<T extends ParseObject> extends ParseLiveListElement<T> {
       }
     }
 
-    _subscription = await LiveQuery()
-        .client
-        .subscribe<T>(queryBuilder, copyObject: object.clone(null));
+    _subscription = await LiveQuery().client.subscribe<T>(
+        QueryBuilder<T>.copy(queryBuilder),
+        copyObject: object.clone(null));
 
     _subscription.on(LiveQueryEvent.update, (T newObject) async {
-      _subscriptionQueue.whenComplete(() async {
-        await ParseLiveList._loadIncludes(newObject,
-            oldObject: super.object, paths: _includes);
-        super.object = newObject;
-      });
+      await ParseLiveList._loadIncludes(newObject,
+          oldObject: super.object, paths: _includes);
+      super.object = newObject;
     });
 
     LiveQuery()

--- a/lib/src/utils/parse_live_list.dart
+++ b/lib/src/utils/parse_live_list.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:parse_server_sdk/src/network/parse_live_query.dart';
 
 import '../../parse_server_sdk.dart';
 


### PR DESCRIPTION
ParseLiveList listens on included objects. LiveQuery is currently not able to do this due to the server implementation.

As this is an useful feature, I added LiveElement.
ParseLiveElement is build on to of ParseLiveListElement and can be used like a mix of LiveQuery and ParseLiveListWidget.
You can get the current ParseObject through a stream.