### PR TITLE
Update HealthCheck

### DIFF
--- a/lib/src/objects/response/parse_response_builder.dart
+++ b/lib/src/objects/response/parse_response_builder.dart
@@ -151,6 +151,6 @@ class _ParseResponseBuilder {
   }
 
   bool isHealthCheck(Response apiResponse) {
-    return apiResponse.body == '{\"status\":\"ok\"}';
+    return ['{\"status\":\"ok\"}', 'OK'].contains(apiResponse.body);
   }
 }


### PR DESCRIPTION
I'm using `docker-parse-server@2.3.1` and at `/parse/health` it returns with `"OK"` string.
This fix adds a new option for health check response.