### PR TITLE
[web] Check web before Platform.isX

### DIFF
--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:devicelocale/devicelocale.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -68,7 +68,9 @@ class ParseInstallation extends ParseObject {
   /// Updates the installation with current device data
   Future<void> _updateInstallation() async {
     //Device type
-    if (Platform.isAndroid) {
+    if (kIsWeb) {
+      set<String>(keyDeviceType, 'web');
+    } else if (Platform.isAndroid) {
       set<String>(keyDeviceType, 'android');
     } else if (Platform.isIOS) {
       set<String>(keyDeviceType, 'ios');

--- a/lib/src/storage/core_store_sem_impl.dart
+++ b/lib/src/storage/core_store_sem_impl.dart
@@ -12,7 +12,7 @@ class CoreStoreSembastImp implements CoreStore {
       factory ??= databaseFactoryIo;
       final SembastCodec codec = getXXTeaSembastCodec(password: password);
       String dbDirectory = '';
-      if (Platform.isIOS || Platform.isAndroid)
+      if (!kIsWeb && (Platform.isIOS || Platform.isAndroid))
         dbDirectory = (await getApplicationDocumentsDirectory()).path;
       final String dbPath = path.join('$dbDirectory/parse', 'parse.db');
       final Database db = await factory.openDatabase(dbPath, codec: codec);


### PR DESCRIPTION
Fixes `Unsupported operation: Platform._operatingSystem` as described in #385 .

dart:io 's Platform.isX is unsupported in web.

The recommended way is using kIsWeb from flutter foundations: https://github.com/flutter/flutter/issues/36126.

This does not enable sembast usage in web. It still needs the [sembast_web package](https://pub.dev/packages/sembast_web).