### PR TITLE
Make web compatible calls for locale and skip PackageInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ It's possible to add other parameters to work with your instance of Parse Server
 	coreStore: await CoreStoreSharedPrefsImp.getInstance()); // Local data storage method. Will use SharedPreferences instead of Sembast as an internal DB
 ```
 
+
+#### Early Web support
+Currently this requires adding `X-Parse-Installation-Id` as an allowed header to parse-server.
+When running directly via docker, set the env var `PARSE_SERVER_ALLOW_HEADERS=X-Parse-Installation-Id`.
+When running via express, set [ParseServerOptions](https://parseplatform.org/parse-server/api/master/ParseServerOptions.html) `allowHeader: ['X-Parse-Installation-Id']`.
+
+Be aware that for web ParseInstallation does include app name, version or package identifier.
+
+
 ## Objects
 You can create custom objects by calling:
 ```dart

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:devicelocale/devicelocale.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -83,7 +83,7 @@ class ParseInstallation extends ParseObject {
     }
 
     //Locale
-    final String locale = kIsWeb ? ui.window.locale.languageCode : await Devicelocale.currentLocale;
+    final String locale = kIsWeb ? ui.window.locale.toString() : await Devicelocale.currentLocale;
     if (locale != null && locale.isNotEmpty) {
       set<String>(keyLocaleIdentifier, locale);
     }

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -83,7 +83,7 @@ class ParseInstallation extends ParseObject {
     }
 
     //Locale
-    final String locale = await Devicelocale.currentLocale;
+    final String locale = kIsWeb ? ui.window.locale.languageCode : await Devicelocale.currentLocale;
     if (locale != null && locale.isNotEmpty) {
       set<String>(keyLocaleIdentifier, locale);
     }
@@ -91,10 +91,12 @@ class ParseInstallation extends ParseObject {
     //Timezone
 
     //App info
-    final PackageInfo packageInfo = await PackageInfo.fromPlatform();
-    set<String>(keyAppName, packageInfo.appName);
-    set<String>(keyAppVersion, packageInfo.version);
-    set<String>(keyAppIdentifier, packageInfo.packageName);
+    if (!kIsWeb) {
+      final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+      set<String>(keyAppName, packageInfo.appName);
+      set<String>(keyAppVersion, packageInfo.version);
+      set<String>(keyAppIdentifier, packageInfo.packageName);
+    }
     set<String>(keyParseVersion, keySdkVersion);
   }
 


### PR DESCRIPTION
Adds to #392 to further improve web compatibility.
General web support issue: #385

Replaces following incompatible packages only for web:

#### Devicelocale.currentLocale (https://github.com/magnatronus/flutter-devicelocale/issues/9)
Replaced by `ui.window.locale.languageCode` from dart:ui package.
This outputs the language as ("en_US", "en_GB"), same as on Android with Devicelocale (Devicelocale returns - dashes for iOS).

#### PackageInfo (https://github.com/flutter/flutter/issues/46609)
Here I opted to remove all the properties coming from PackageInfo.
Parsing the yaml file and injecting them inside the app somehow could work, but I would rather wait and hope for PackageInfo to support web sometime in the future.

Pending Readme changes.