### PR TITLE
ParseLiveList: NoSuchMethodError

### DIFF
--- a/lib/src/utils/parse_live_list.dart
+++ b/lib/src/utils/parse_live_list.dart
@@ -877,7 +877,7 @@ class _ParseLiveListWidgetState<T extends ParseObject>
 
   @override
   void dispose() {
-    _liveList.dispose();
+    _liveList?.dispose();
     _liveList = null;
     super.dispose();
   }


### PR DESCRIPTION
In theory this should not make any difference. In practise sometimes an error gets thrown:

> The following NoSuchMethodError was thrown while finalizing the widget tree:
> The method 'dispose' was called on null.
> Receiver: null
> Tried calling: dispose()