### PR TITLE
Web file upload: set content type to "text/plain" incase neighter name nor url is set

### DIFF
--- a/lib/src/objects/parse_file_web.dart
+++ b/lib/src/objects/parse_file_web.dart
@@ -46,7 +46,9 @@ class ParseWebFile extends ParseFileBase {
     }
 
     final Map<String, String> headers = <String, String>{
-      HttpHeaders.contentTypeHeader: getContentType(path.extension(url))
+      HttpHeaders.contentTypeHeader: url ?? name != null
+          ? getContentType(path.extension(url ?? name))
+          : 'text/plain'
     };
     try {
       final String uri = _client.data.serverUrl + '$_path';


### PR DESCRIPTION
This probably breaks the extension at the uploaded file, but otherwise the upload would fail with a server error.
I think this is the better choice.