### PR TITLE
LiveQuery reconnecting intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,13 @@ LiveQuery server.
 liveQuery.client.unSubscribe(subscription);
 ```
 
+__Disconnection__
+In case the client's connection to the server breaks,
+LiveQuery will automatically try to reconnect.
+LiveQuery will wait at increasing intervals between reconnection attempts.
+By default, these intervals are set to `[0, 500, 1000, 2000, 5000, 10000]` for mobile and `[0, 500, 1000, 2000, 5000]` for web.
+You can change these by providing a custom list using the `liveListRetryIntervals` parameter at `Parse.initialize()` ("-1" means "do not try to reconnect").
+
 ## ParseLiveList
 ParseLiveList makes implementing a dynamic List as simple as possible.
 

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -96,6 +96,7 @@ class Parse {
     Map<String, ParseObjectConstructor> registeredSubClassMap,
     ParseUserConstructor parseUserConstructor,
     ParseFileConstructor parseFileConstructor,
+    List<int> liveListRetryIntervals,
   }) async {
     final String url = removeTrailingSlash(serverUrl);
 
@@ -114,6 +115,7 @@ class Parse {
       registeredSubClassMap: registeredSubClassMap,
       parseUserConstructor: parseUserConstructor,
       parseFileConstructor: parseFileConstructor,
+      liveListRetryIntervals: liveListRetryIntervals,
     );
 
     _hasBeenInitialized = true;

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -95,6 +95,7 @@ class Parse {
     CoreStore coreStore,
     Map<String, ParseObjectConstructor> registeredSubClassMap,
     ParseUserConstructor parseUserConstructor,
+    ParseFileConstructor parseFileConstructor,
   }) async {
     final String url = removeTrailingSlash(serverUrl);
 
@@ -112,6 +113,7 @@ class Parse {
       store: coreStore,
       registeredSubClassMap: registeredSubClassMap,
       parseUserConstructor: parseUserConstructor,
+      parseFileConstructor: parseFileConstructor,
     );
 
     _hasBeenInitialized = true;

--- a/lib/src/data/parse_core_data.dart
+++ b/lib/src/data/parse_core_data.dart
@@ -29,6 +29,7 @@ class ParseCoreData {
     Map<String, ParseObjectConstructor> registeredSubClassMap,
     ParseUserConstructor parseUserConstructor,
     ParseFileConstructor parseFileConstructor,
+    List<int> liveListRetryIntervals,
   }) async {
     _instance = ParseCoreData._init(appId, serverUrl);
 
@@ -59,6 +60,13 @@ class ParseCoreData {
     if (securityContext != null) {
       _instance.securityContext = securityContext;
     }
+    if (liveListRetryIntervals != null) {
+      _instance.liveListRetryIntervals = liveListRetryIntervals;
+    } else {
+      _instance.liveListRetryIntervals = kIsWeb
+          ? <int>[0, 500, 1000, 2000, 5000]
+          : <int>[0, 500, 1000, 2000, 5000, 10000];
+    }
 
     _instance._subClassHandler = ParseSubClassHandler(
       registeredSubClassMap: registeredSubClassMap,
@@ -79,6 +87,7 @@ class ParseCoreData {
   bool debug;
   CoreStore storage;
   ParseSubClassHandler _subClassHandler;
+  List<int> liveListRetryIntervals;
 
   void registerSubClass(
       String className, ParseObjectConstructor objectConstructor) {

--- a/lib/src/network/parse_live_query.dart
+++ b/lib/src/network/parse_live_query.dart
@@ -76,8 +76,7 @@ class LiveQueryReconnectingController with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
   }
 
-  // -1 means "do not try to reconnect",
-  static const List<int> retryInterval = <int>[0, 500, 1000, 2000, 5000, 10000];
+  static List<int> get retryInterval => ParseCoreData().liveListRetryIntervals;
   static const String DEBUG_TAG = 'LiveQueryReconnectingController';
 
   final Function _reconnect;

--- a/lib/src/network/parse_live_query_web.dart
+++ b/lib/src/network/parse_live_query_web.dart
@@ -71,8 +71,7 @@ class LiveQueryReconnectingController with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
   }
 
-  // -1 means "do not try to reconnect",
-  static const List<int> retryInterval = <int>[0, 500, 1000, 2000, 5000];
+  static List<int> get retryInterval => ParseCoreData().liveListRetryIntervals;
   static const String DEBUG_TAG = 'LiveQueryReconnectingController';
 
   final Function _reconnect;


### PR DESCRIPTION
LiveQuery reconnecting intervals should be adjustable at Parse().initialize().
Further information in the README.

And I've noticed, I missed parseFileConstructor at Parse().initialize(). Oops.