### PR TITLE
Replace devicelocale by Platform.localeName call

### DIFF
--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -7,7 +7,6 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:devicelocale/devicelocale.dart';
 import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -85,7 +85,7 @@ class ParseInstallation extends ParseObject {
     //Locale
     final String locale = parseIsWeb
         ? ui.window.locale.toString()
-        : await Devicelocale.currentLocale;
+        : Platform.localeName;
     if (locale != null && locale.isNotEmpty) {
       set<String>(keyLocaleIdentifier, locale);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,5 +29,6 @@ dependencies:
 
 dev_dependencies:
   # Testing
-  test: ^1.15.3
+  flutter_test:
+    sdk: flutter
   mockito: ^4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   path_provider: ^1.6.14
   uuid: ^2.2.2
   package_info: ^0.4.3
-  devicelocale: ^0.3.1
   meta: ^1.1.8
   path: ^1.7.0
 

--- a/test/parse_client_configuration_test.dart
+++ b/test/parse_client_configuration_test.dart
@@ -1,6 +1,6 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:parse_server_sdk/parse_server_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:test/test.dart';
 
 void main() {
   SharedPreferences.setMockInitialValues(Map<String, String>());

--- a/test/parse_query_test.dart
+++ b/test/parse_query_test.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:parse_server_sdk/parse_server_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:test/test.dart';
 
 class MockClient extends Mock implements ParseHTTPClient {}
 


### PR DESCRIPTION
Devicelocale is not maintained a lot and currently throws errors for me when building a Android APK release.

It was only used in one place for the installation, and can be replaced by Platform.localeName (not working for Web, so keeping the alternate web call).
Now the package has one less dependency on a not greatly maintained package.

A throughout example or possibilities to get Locale: https://stackoverflow.com/a/62825776/1387765

Also replaces test (dart only), by flutter_test to fix tests.