### PR TITLE
Add WEB-support for CoreStoreSembastImp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ await Parse().initialize(
 ```
 
 If you want to use secure storage or use the Flutter web/desktop SDK, please change to the below instance of CoreStorage as it has no dependencies on Flutter.
+
+**The `CoreStoreSembastImp` does not encrypt the data!** (Web is not safe anyway. Encrypt fields manually as needed.)
 ```dart
 
 await Parse().initialize(

--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -19,6 +19,7 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:sembast/sembast.dart';
 import 'package:sembast/sembast_io.dart';
+import 'package:sembast_web/sembast_web.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';

--- a/lib/parse_server_sdk_dart.dart
+++ b/lib/parse_server_sdk_dart.dart
@@ -14,6 +14,7 @@ import 'package:parse_server_sdk/src/network/parse_websocket.dart'
 import 'package:path/path.dart' as path;
 import 'package:sembast/sembast.dart';
 import 'package:sembast/sembast_io.dart';
+import 'package:sembast_web/sembast_web.dart';
 import 'package:uuid/uuid.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:xxtea/xxtea.dart';

--- a/lib/src/storage/core_store_sem_impl.dart
+++ b/lib/src/storage/core_store_sem_impl.dart
@@ -14,8 +14,16 @@ class CoreStoreSembastImp implements CoreStore {
       if (!parseIsWeb &&
           (Platform.isIOS || Platform.isAndroid || Platform.isMacOS))
         dbDirectory = (await getApplicationDocumentsDirectory()).path;
+      assert(() {
+        if (parseIsWeb) {
+          print(
+              'Warning: CoreStoreSembastImp of the Parse_Server_SDK does not encrypt the database on WEB.');
+        }
+        return true;
+      }());
       final String dbPath = path.join('$dbDirectory/parse', 'parse.db');
-      final Database db = await factory.openDatabase(dbPath, codec: !parseIsWeb ? getXXTeaSembastCodec(password: password) : null);
+      final Database db = await factory.openDatabase(dbPath,
+          codec: !parseIsWeb ? getXXTeaSembastCodec(password: password) : null);
       _instance =
           CoreStoreSembastImp._internal(db, StoreRef<String, String>.main());
     }

--- a/lib/src/storage/core_store_sem_impl.dart
+++ b/lib/src/storage/core_store_sem_impl.dart
@@ -9,14 +9,13 @@ class CoreStoreSembastImp implements CoreStore {
   static Future<CoreStore> getInstance(
       {DatabaseFactory factory, String password = 'flutter_sdk'}) async {
     if (_instance == null) {
-      factory ??= databaseFactoryIo;
-      final SembastCodec codec = getXXTeaSembastCodec(password: password);
+      factory ??= !parseIsWeb ? databaseFactoryIo : databaseFactoryWeb;
       String dbDirectory = '';
       if (!parseIsWeb &&
           (Platform.isIOS || Platform.isAndroid || Platform.isMacOS))
         dbDirectory = (await getApplicationDocumentsDirectory()).path;
       final String dbPath = path.join('$dbDirectory/parse', 'parse.db');
-      final Database db = await factory.openDatabase(dbPath, codec: codec);
+      final Database db = await factory.openDatabase(dbPath, codec: !parseIsWeb ? getXXTeaSembastCodec(password: password) : null);
       _instance =
           CoreStoreSembastImp._internal(db, StoreRef<String, String>.main());
     }

--- a/lib/src/storage/core_store_sem_impl.dart
+++ b/lib/src/storage/core_store_sem_impl.dart
@@ -17,7 +17,8 @@ class CoreStoreSembastImp implements CoreStore {
         }
         return true;
       }());
-      final Database db = await factory.openDatabase(dbPath, codec: !parseIsWeb ? getXXTeaSembastCodec(password: password) : null));
+      final Database db = await factory.openDatabase(dbPath,
+          codec: !parseIsWeb ? getXXTeaSembastCodec(password: password) : null);
       _instance =
           CoreStoreSembastImp._internal(db, StoreRef<String, String>.main());
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 
   #Database
   sembast: ^2.4.7+6
+  sembast_web: '>=1.0.0'
   xxtea: ^2.0.3
   shared_preferences: ^0.5.10
 


### PR DESCRIPTION
This is pretty much the same PR as @nstrelow's  #394.

Please have a look at  #394 for a detailed explanation of the problem.

I think, although it's not optimal,  not encrypting the database is the best trade we can make.

As far as I know, this should add full web support to the SDK. (#385)