### PR TITLE
Add support for custom object IDs

### DIFF
--- a/packages/dart/lib/src/objects/parse_base.dart
+++ b/packages/dart/lib/src/objects/parse_base.dart
@@ -73,7 +73,11 @@ abstract class ParseBase {
 
   /// Converts object to [String] in JSON format
   @protected
-  Map<String, dynamic> toJson({bool full, bool forApiRQ = false}) {
+  Map<String, dynamic> toJson({
+    bool full,
+    bool forApiRQ = false,
+    bool allowCustomObjectId = false,
+    }) {
     final Map<String, dynamic> map = <String, dynamic>{
       keyVarClassName: parseClassName,
     };
@@ -103,7 +107,10 @@ abstract class ParseBase {
       map.remove(keyVarUpdatedAt);
       map.remove(keyVarClassName);
       //map.remove(keyVarAcl);
-      map.remove(keyVarObjectId);
+
+      if (!allowCustomObjectId) {
+        map.remove(keyVarObjectId);
+      }
       map.remove(keyParamSessionToken);
     }
 

--- a/packages/dart/lib/src/objects/parse_file_base.dart
+++ b/packages/dart/lib/src/objects/parse_file_base.dart
@@ -28,7 +28,11 @@ abstract class ParseFileBase extends ParseObject {
   bool get saved => url != null;
 
   @override
-  Map<String, dynamic> toJson({bool full = false, bool forApiRQ = false}) =>
+  Map<String, dynamic> toJson({
+    bool full = false,
+    bool forApiRQ = false,
+    bool allowCustomObjectId = false,
+  }) =>
       <String, String>{'__type': keyFile, 'name': name, 'url': url};
 
   @override

--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -95,13 +95,13 @@ class ParseInstallation extends ParseObject {
   }
 
   @override
-  Future<ParseResponse> create() async {
+  Future<ParseResponse> create({bool allowCustomObjectId = false}) async {
     final bool isCurrent = await ParseInstallation.isCurrent(this);
     if (isCurrent) {
       await _updateInstallation();
     }
 
-    final ParseResponse parseResponse = await _create();
+    final ParseResponse parseResponse = await _create(allowCustomObjectId: allowCustomObjectId);
     if (parseResponse.success && isCurrent) {
       saveInStorage(keyParseStoreInstallation);
     }
@@ -157,10 +157,13 @@ class ParseInstallation extends ParseObject {
   }
 
   /// Creates a new object and saves it online
-  Future<ParseResponse> _create() async {
+  Future<ParseResponse> _create({bool allowCustomObjectId = false}) async {
     try {
       final String uri = '${_client.data.serverUrl}$keyEndPointInstallations';
-      final String body = json.encode(toJson(forApiRQ: true));
+      final String body = json.encode(toJson(
+        forApiRQ: true,
+        allowCustomObjectId: allowCustomObjectId,
+      ));
       final Map<String, String> headers = <String, String>{
         keyHeaderContentType: keyHeaderContentTypeJson
       };

--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -65,10 +65,13 @@ class ParseObject extends ParseBase implements ParseCloneable {
   }
 
   /// Creates a new object and saves it online
-  Future<ParseResponse> create() async {
+  Future<ParseResponse> create({bool allowCustomObjectId = false}) async {
     try {
       final Uri url = getSanitisedUri(_client, '$_path');
-      final String body = json.encode(toJson(forApiRQ: true));
+      final String body = json.encode(toJson(
+        forApiRQ: true,
+        allowCustomObjectId: allowCustomObjectId,
+      ));
       _saveChanges();
       final Response result =
           await _client.post<String>(url.toString(), data: body);


### PR DESCRIPTION
Adds support for custom object IDs that are generated on the client side and sent during creation of Parse objects.

This option needs to be enabled on the Parse server. 
Example from Back4app documentation: https://www.back4app.com/docs/platform/custom-parse-options