### PR TITLE
added doNotSendInstallationID parameter to user functions

### DIFF
--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -175,7 +175,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
           await _client.post<String>(url.toString(),
               options: Options(headers: <String, String>{
                 keyHeaderRevocableSession: '1',
-                if (installationId != null)
+                if (installationId != null && !parseIsWeb)
                   keyHeaderInstallationId: installationId,
               }),
               data: body);
@@ -207,7 +207,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null) keyHeaderInstallationId: installationId,
+          if (installationId != null && !parseIsWeb)
+            keyHeaderInstallationId: installationId,
         }),
       );
 
@@ -230,7 +231,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null) keyHeaderInstallationId: installationId,
+          if (installationId != null && !parseIsWeb)
+            keyHeaderInstallationId: installationId,
         }),
         data: jsonEncode(<String, dynamic>{
           'authData': <String, dynamic>{
@@ -263,7 +265,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null) keyHeaderInstallationId: installationId,
+          if (installationId != null && !parseIsWeb)
+            keyHeaderInstallationId: installationId,
         }),
         data: jsonEncode(<String, dynamic>{
           'authData': <String, dynamic>{provider: authData}

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -152,7 +152,11 @@ class ParseUser extends ParseObject implements ParseCloneable {
   /// After creating a new user via [Parse.create] call this method to register
   /// that user on Parse
   /// By setting [allowWithoutEmail] to `true`, you can sign up without setting an email
-  Future<ParseResponse> signUp({bool allowWithoutEmail = false}) async {
+  /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
+  /// This option is especially useful if you are running you application on web and you don't have permission to add 'X-Parse-Installation-Id' as an allowed header on your parse-server.
+  Future<ParseResponse> signUp(
+      {bool allowWithoutEmail = false,
+      bool doNotSendInstallationID = false}) async {
     forgetLocalSession();
 
     try {
@@ -161,7 +165,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
           return null;
         } else {
           assert(() {
-            print('It is recommended to only allow user signUp with a ');
+            print(
+                'It is recommended to only allow user signUp with an email beeing set.');
             return true;
           }());
         }
@@ -175,7 +180,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
           await _client.post<String>(url.toString(),
               options: Options(headers: <String, String>{
                 keyHeaderRevocableSession: '1',
-                if (installationId != null && !parseIsWeb)
+                if (installationId != null && !doNotSendInstallationID)
                   keyHeaderInstallationId: installationId,
               }),
               data: body);
@@ -191,7 +196,9 @@ class ParseUser extends ParseObject implements ParseCloneable {
   ///
   /// Once a user is created using [Parse.create] and a username and password is
   /// provided, call this method to login.
-  Future<ParseResponse> login() async {
+  /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
+  /// This option is especially useful if you are running you application on web and you don't have permission to set 'X-Parse-Installation-Id' as an allowed header on your parse-server.
+  Future<ParseResponse> login({bool doNotSendInstallationID = false}) async {
     forgetLocalSession();
 
     try {
@@ -207,7 +214,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null && !parseIsWeb)
+          if (installationId != null && !doNotSendInstallationID)
             keyHeaderInstallationId: installationId,
         }),
       );
@@ -219,8 +226,11 @@ class ParseUser extends ParseObject implements ParseCloneable {
     }
   }
 
-  // Logs in a user anonymously
-  Future<ParseResponse> loginAnonymous() async {
+  /// Logs in a user anonymously
+  /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
+  /// This option is especially useful if you are running you application on web and you don't have permission to add 'X-Parse-Installation-Id' as an allowed header on your parse-server.
+  Future<ParseResponse> loginAnonymous(
+      {bool doNotSendInstallationID = false}) async {
     forgetLocalSession();
     try {
       final Uri url = getSanitisedUri(_client, '$keyEndPointUsers');
@@ -231,7 +241,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null && !parseIsWeb)
+          if (installationId != null && !doNotSendInstallationID)
             keyHeaderInstallationId: installationId,
         }),
         data: jsonEncode(<String, dynamic>{
@@ -249,15 +259,21 @@ class ParseUser extends ParseObject implements ParseCloneable {
     }
   }
 
-  // Logs in a user using a service
-  static Future<ParseResponse> loginWith(
-      String provider, Object authData) async {
+  /// Logs in a user using a service
+  /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
+  /// This option is especially useful if you are running you application on web and you don't have permission to add 'X-Parse-Installation-Id' as an allowed header on your parse-server.
+  static Future<ParseResponse> loginWith(String provider, Object authData,
+      {bool doNotSendInstallationID = false}) async {
     final ParseUser user = ParseUser.createUser();
-    final ParseResponse response = await user._loginWith(provider, authData);
+    final ParseResponse response = await user._loginWith(provider, authData,
+        doNotSendInstallationID: doNotSendInstallationID);
     return response;
   }
 
-  Future<ParseResponse> _loginWith(String provider, Object authData) async {
+  /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
+  /// This option is especially useful if you are running you application on web and you don't have permission to add 'X-Parse-Installation-Id' as an allowed header on your parse-server.
+  Future<ParseResponse> _loginWith(String provider, Object authData,
+      {bool doNotSendInstallationID = false}) async {
     try {
       final Uri url = getSanitisedUri(_client, '$keyEndPointUsers');
       final String installationId = await _getInstallationId();
@@ -265,7 +281,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         url.toString(),
         options: Options(headers: <String, String>{
           keyHeaderRevocableSession: '1',
-          if (installationId != null && !parseIsWeb)
+          if (installationId != null && !doNotSendInstallationID)
             keyHeaderInstallationId: installationId,
         }),
         data: jsonEncode(<String, dynamic>{

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -10,7 +10,11 @@ dependencies:
   flutter:
     sdk: flutter
 
-  parse_server_sdk: ^2.0.0
+  parse_server_sdk:
+    git:
+      url: git://github.com/fischerscode/Parse-SDK-Flutter.git
+      ref: production-branch-1
+      path: packages/dart
 
   # Networking
   dio: ^3.0.10

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   parse_server_sdk:
     git:
       url: git://github.com/fischerscode/Parse-SDK-Flutter.git
-      ref: production-branch-1
+      ref: issue-490
       path: packages/dart
 
   # Networking

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
 
   parse_server_sdk:
     git:
-      url: git://github.com/fischerscode/Parse-SDK-Flutter.git
-      ref: issue-490
+      url: git://github.com/parse-community/Parse-SDK-Flutter.git
+      ref: development
       path: packages/dart
 
   # Networking


### PR DESCRIPTION
This is a fix for #490.

As reported by @gorillatapstudio and @nstrelow, it does not seem to be possible to add custom headers to the parse-server instance when using back4app. As the `X-Parse-Installation-Id` header is not allowed by default, user login does not work on web due to CORS restrictions.

This PR adds the option to prevent the SDK from using this header.

There should be no breaking change, as the default behavior did not change.