### PR TITLE
Fix CoreStoreSembastImp / Fix ParseACL / New Query Method / Updated Dependencies version / Fix error message parse_live_query.dart

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.1.0
-Option para uses ParseHTTPClient (default) ou ParseDioClient
+Option para uses ParseHTTPClient (default) or ParseDioClient
 Make autoSendSessionId parameter default TRUE
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0
 Option para uses ParseHTTPClient (default) ou ParseDioClient
+Make autoSendSessionId parameter default TRUE
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529
 Add method excludeKeys: Exclude specific fields from the returned query

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.1.0
+Option para uses ParseHTTPClient (default) ou ParseDioClient
+Fix ParseACL with no default value in setReadAccess and setWriteAccess
+Fix ParseInstallation - Quick updates produce concurrency errors #529
+Add method excludeKeys: Exclude specific fields from the returned query
+Changed to the method to POST in the Login
+Fix upload file using ParseDioClient
+Updated Dependencies version in pubspec.yaml
+Minor fix
 ## 2.0.1
 Fixed network exceptions. [#482](https://github.com/parse-community/Parse-SDK-Flutter/pull/482)
 

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0
-Option para uses ParseHTTPClient (default) or ParseDioClient
+Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
+    **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
 Make autoSendSessionId parameter default TRUE
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -2,13 +2,12 @@
 Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
     **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
 Make autoSendSessionId parameter default TRUE
-Fix ParseACL with no default value in setReadAccess and setWriteAccess
-Fix ParseInstallation - Quick updates produce concurrency errors #529
 Added method excludeKeys: Exclude specific fields from the returned query
-Changed to the method to POST in the Login
-Fix upload file using ParseDioClient
-Updated Dependencies version in pubspec.yaml
-Minor fix
+Changed to the method POST on Login
+Bug fixes
+General improvements
+Updated dependencies
+
 ## 2.0.1
 Fixed network exceptions. [#482](https://github.com/parse-community/Parse-SDK-Flutter/pull/482)
 

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.1.0
 Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
     **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
-Make autoSendSessionId parameter default TRUE
 Added method excludeKeys: Exclude specific fields from the returned query
 Changed to the method POST on Login
 Bug fixes

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -3,7 +3,7 @@ Option para uses ParseHTTPClient (default) or ParseDioClient
 Make autoSendSessionId parameter default TRUE
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529
-Add method excludeKeys: Exclude specific fields from the returned query
+Added method excludeKeys: Exclude specific fields from the returned query
 Changed to the method to POST in the Login
 Fix upload file using ParseDioClient
 Updated Dependencies version in pubspec.yaml

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -20,7 +20,7 @@ This is a work in progress and we are consistently updating it. Please let us kn
 To install, either add to your pubspec.yaml
 ```yml
 dependencies:  
-    parse_server_sdk: ^2.0.1
+    parse_server_sdk: ^2.1.0
 ```
 or clone this repository and add to your project. As this is an early development with multiple contributors, it is probably best to download/clone and keep updating as an when a new feature is added.
 

--- a/packages/dart/lib/parse_server_sdk.dart
+++ b/packages/dart/lib/parse_server_sdk.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:mime_type/mime_type.dart';
-import 'package:parse_server_sdk/src/network/parse_dio_client.dart';
+import 'package:parse_server_sdk/src/network/parse_http_client.dart';
 import 'package:parse_server_sdk/src/network/parse_websocket.dart'
     as parse_web_socket;
 import 'package:path/path.dart' as path;
@@ -94,7 +94,7 @@ class Parse {
     String clientKey,
     String masterKey,
     String sessionId,
-    bool autoSendSessionId,
+    bool autoSendSessionId = true,
     SecurityContext securityContext,
     CoreStore coreStore,
     Map<String, ParseObjectConstructor> registeredSubClassMap,

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '2.0.1';
+const String keySdkVersion = '2.1.0';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/data/parse_core_data.dart
+++ b/packages/dart/lib/src/data/parse_core_data.dart
@@ -125,7 +125,7 @@ class ParseCoreData {
   String fileDirectory;
   Stream<void> appResumedStream;
   ParseClientCreator clientCreator =
-      ({bool sendSessionId, SecurityContext securityContext}) => ParseDioClient(
+      ({bool sendSessionId, SecurityContext securityContext}) => ParseHTTPClient(
           sendSessionId: sendSessionId, securityContext: securityContext);
 
   void registerSubClass(

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -98,8 +98,7 @@ class ParseDioClient extends ParseClient {
       final dio.Response<String> dioResponse = await _client.post<String>(
         path,
         data: data,
-        options: _Options(
-            headers: options?.headers, responseType: dio.ResponseType.bytes),
+        options: _Options(headers: options?.headers),
         onSendProgress: onSendProgress,
       );
       return ParseNetworkResponse(

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -46,7 +46,7 @@ class LiveQueryReconnectingController {
       connectivityProvider.connectivityStream.listen(_connectivityChanged);
     } else {
       print(
-          'LiveQuery does not work, if there is ParseConnectivityProvider provided.');
+          'LiveQuery does not work, if there is no ParseConnectivityProvider provided.');
     }
     _eventStream.listen((LiveQueryClientEvent event) {
       switch (event) {

--- a/packages/dart/lib/src/network/parse_query.dart
+++ b/packages/dart/lib/src/network/parse_query.dart
@@ -86,6 +86,13 @@ class QueryBuilder<T extends ParseObject> {
     limiters['keys'] = concatenateArray(keys);
   }
 
+  ///Exclude specific fields from the returned query
+  ///
+  /// [String] keys not will return the columns of a result you want the data for
+  void excludeKeys(List<String> keys) {
+    limiters['excludeKeys'] = concatenateArray(keys);
+  }
+
   /// Includes other ParseObjects stored as a Pointer
   void includeObject(List<String> objectTypes) {
     limiters['include'] = concatenateArray(objectTypes);

--- a/packages/dart/lib/src/objects/parse_acl.dart
+++ b/packages/dart/lib/src/objects/parse_acl.dart
@@ -51,7 +51,7 @@ class ParseACL {
   }
 
   ///Set whether the given user id is allowed to read this object.
-  void setReadAccess({@required String userId, bool allowed}) {
+  void setReadAccess({@required String userId, bool allowed = true}) {
     if (userId == null) {
       throw 'cannot setReadAccess for null userId';
     }
@@ -74,7 +74,7 @@ class ParseACL {
   }
 
   ///Set whether the given user id is allowed to write this object.
-  void setWriteAccess({@required String userId, bool allowed}) {
+  void setWriteAccess({@required String userId, bool allowed = true}) {
     if (userId == null) {
       throw 'cannot setWriteAccess for null userId';
     }

--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -104,6 +104,7 @@ class ParseInstallation extends ParseObject {
     final ParseResponse parseResponse =
         await _create(allowCustomObjectId: allowCustomObjectId);
     if (parseResponse.success && isCurrent) {
+      clearUnsavedChanges();
       await saveInStorage(keyParseStoreInstallation);
     }
     return parseResponse;
@@ -119,6 +120,7 @@ class ParseInstallation extends ParseObject {
     //ParseResponse parseResponse = await super.save();
     final ParseResponse parseResponse = await _save();
     if (parseResponse.success && isCurrent) {
+      clearUnsavedChanges();
       await saveInStorage(keyParseStoreInstallation);
     }
     return parseResponse;

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -13,7 +13,19 @@ class CoreStoreSembastImp implements CoreStore {
       assert(() {
         if (parseIsWeb) {
           print(
+              '***********************************************************************************************************');
+          print(
               'Warning: CoreStoreSembastImp of the Parse_Server_SDK does not encrypt the database on WEB.');
+          print(
+              '***********************************************************************************************************');
+        }
+        if (password == 'flutter_sdk') {
+          print(
+              '***********************************************************************************************************');
+          print(
+              'Warning: CoreStoreSembastImp uses the default password. Specify a custom one for increased security.');
+          print(
+              '***********************************************************************************************************');
         }
         return true;
       }());

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -23,7 +23,7 @@ class CoreStoreSembastImp implements CoreStore {
           print(
               '***********************************************************************************************************');
           print(
-              'Warning: CoreStoreSembastImp uses the default password. Specify a custom one for increased security.');
+              'Warning: CoreStoreSembastImp uses the default password. Specify a custom password for increased security.');
           print(
               '***********************************************************************************************************');
         }

--- a/packages/dart/lib/src/utils/parse_login_helpers.dart
+++ b/packages/dart/lib/src/utils/parse_login_helpers.dart
@@ -15,3 +15,7 @@ Map<String, dynamic> google(String token, String id, String idToken) {
     'id_token': idToken
   };
 }
+
+Map<String, dynamic> apple(String token, String id) {
+  return <String, dynamic>{'token': token, 'id': id};
+}

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 2.0.1
+version: 2.1.0
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
 
   # Utils
   uuid: ^2.2.2
-  meta: ^1.3.0
+  meta: ^1.2.4
   path: ^1.7.0
   mime_type: ^0.3.2
 
 dev_dependencies:
   # Testing
-  test: ^1.16.2
-  mockito: ^4.1.4
+  test: ^1.15.7
+  mockito: ^4.1.3

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -14,17 +14,17 @@ dependencies:
   web_socket_channel: ^1.1.0
 
   #Database
-  sembast: ^2.4.7+6
-  sembast_web: ^1.2.0
+  sembast: ^2.4.8+1
+  sembast_web: ^1.2.0+1
   xxtea: ^2.0.3
 
   # Utils
   uuid: ^2.2.2
-  meta: ^1.1.8
+  meta: ^1.2.4
   path: ^1.7.0
   mime_type: ^0.3.2
 
 dev_dependencies:
   # Testing
-  test: ^1.15.3
-  mockito: ^4.1.1
+  test: ^1.15.7
+  mockito: ^4.1.3

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -11,20 +11,20 @@ dependencies:
   # Networking
   dio: ^3.0.10
   http: ^0.12.2
-  web_socket_channel: ^1.1.0
+  web_socket_channel: ^1.2.0
 
   #Database
-  sembast: ^2.4.8+1
+  sembast: ^2.4.9
   sembast_web: ^1.2.0+1
   xxtea: ^2.0.3
 
   # Utils
   uuid: ^2.2.2
-  meta: ^1.2.4
+  meta: ^1.3.0
   path: ^1.7.0
   mime_type: ^0.3.2
 
 dev_dependencies:
   # Testing
-  test: ^1.15.7
-  mockito: ^4.1.3
+  test: ^1.16.2
+  mockito: ^4.1.4

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -4,7 +4,7 @@ Make autoSendSessionId parameter default TRUE
 Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529
-Add method excludeKeys: Exclude specific fields from the returned query
+Added method excludeKeys: Exclude specific fields from the returned query
 Changed to the method to POST in the Login
 Fix upload file using ParseDioClient
 Updated Dependencies version in pubspec.yaml

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -2,14 +2,11 @@
 Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
     **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
 Make autoSendSessionId parameter default TRUE
-Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
-Fix ParseACL with no default value in setReadAccess and setWriteAccess
-Fix ParseInstallation - Quick updates produce concurrency errors #529
 Added method excludeKeys: Exclude specific fields from the returned query
-Changed to the method to POST in the Login
-Fix upload file using ParseDioClient
-Updated Dependencies version in pubspec.yaml
-Minor fix
+Changed to the method POST on Login
+Bug fixes
+General improvements
+Updated dependencies
 
 ## 2.0.1
 Fixed network exceptions. [#482](https://github.com/parse-community/Parse-SDK-Flutter/pull/482)

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0
 Option para uses ParseHTTPClient (default) ou ParseDioClient
+Make autoSendSessionId parameter default TRUE
 Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
 Fix ParseACL with no default value in setReadAccess and setWriteAccess
 Fix ParseInstallation - Quick updates produce concurrency errors #529

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.1.0
+Option para uses ParseHTTPClient (default) ou ParseDioClient
+Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
+Fix ParseACL with no default value in setReadAccess and setWriteAccess
+Fix ParseInstallation - Quick updates produce concurrency errors #529
+Add method excludeKeys: Exclude specific fields from the returned query
+Changed to the method to POST in the Login
+Fix upload file using ParseDioClient
+Updated Dependencies version in pubspec.yaml
+Minor fix
+
 ## 2.0.1
 Fixed network exceptions. [#482](https://github.com/parse-community/Parse-SDK-Flutter/pull/482)
 

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0
-Option para uses ParseHTTPClient (default) or ParseDioClient
+Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
+    **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
 Make autoSendSessionId parameter default TRUE
 Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
 Fix ParseACL with no default value in setReadAccess and setWriteAccess

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.1.0
-Option para uses ParseHTTPClient (default) ou ParseDioClient
+Option para uses ParseHTTPClient (default) or ParseDioClient
 Make autoSendSessionId parameter default TRUE
 Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
 Fix ParseACL with no default value in setReadAccess and setWriteAccess

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.1.0
 Option para uses ParseHTTPClient (default) or ParseDioClient (slow on Flutter Web).
     **BREAKING CHANGE** if use progress callback at the file upload in version 2.0.1
-Make autoSendSessionId parameter default TRUE
 Added method excludeKeys: Exclude specific fields from the returned query
 Changed to the method POST on Login
 Bug fixes

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -14,7 +14,7 @@ This is a work in progress and we are consistently updating it. Please let us kn
 To install, either add to your pubspec.yaml
 ```yml
 dependencies:  
-    parse_server_sdk: ^2.0.1
+    parse_server_sdk: ^2.1.0
 ```
 or clone this repository and add to your project. As this is an early development with multiple contributors, it is probably best to download/clone and keep updating as an when a new feature is added.
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -61,16 +61,17 @@ When running via express, set [ParseServerOptions](https://parseplatform.org/par
 Be aware that for web ParseInstallation does include app name, version or package identifier automatically. You should manually provide this data as described [here](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/docs/migrate-1-0-28.md#optional-provide-app-information-on-web);
 
 #### Network client
-By default, this SDK uses the `ParseDioClient`. This client supports the most features (for example a progress callback at the file upload).
-A benchmark has shown, that dio is slower than http on web. If you want to use the `ParseHTTPClient`, which uses the http network library,
+By default, this SDK uses the `ParseHTTPClient`.
+Another option is use `ParseDioClient`. This client supports the most features (for example a progress callback at the file upload), but a benchmark has shown, that dio is slower than http on web.
+
+If you want to use the `ParseDioClient`, which uses the dio network library,
 you can provide a custom `ParseClientCreator` at the initialization of the SDK.
 ```dart
 await Parse().initialize(
   //...
-  clientCreator: ({bool sendSessionId, SecurityContext securityContext}) => ParseHTTPClient(sendSessionId: sendSessionId, securityContext: securityContext),
+  clientCreator: ({bool sendSessionId, SecurityContext securityContext}) => ParseDioClient(sendSessionId: sendSessionId, securityContext: securityContext),
 );
 ```
-
 
 ## Objects
 You can create custom objects by calling:
@@ -728,7 +729,7 @@ For Google and the example below, we used the library provided at https://pub.de
 class OAuthLogin {
   final GoogleSignIn _googleSignIn = GoogleSignIn( scopes: ['email', 'https://www.googleapis.com/auth/contacts.readonly'] );
   
-  sigInGoogle() async {
+  signInGoogle() async {
     GoogleSignInAccount account = await _googleSignIn.signIn();
     GoogleSignInAuthentication authentication = await account.authentication;
     await ParseUser.loginWith(

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -7,18 +7,18 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-  sembast: ^2.0.1
-  shared_preferences: ^0.5.0
+  cupertino_icons: ^1.0.0
+  sembast: ^2.4.8+1
+  shared_preferences: ^0.5.12+4
 
-  path_provider: ^1.6.14
+  path_provider: ^1.6.27
 
 dev_dependencies:
   parse_server_sdk_flutter:
     path: ../
   flutter_test:
     sdk: flutter
-  mockito: ^4.0.0
+  mockito: ^4.1.3
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/flutter/lib/parse_server_sdk.dart
+++ b/packages/flutter/lib/parse_server_sdk.dart
@@ -18,8 +18,8 @@ export 'package:parse_server_sdk/parse_server_sdk.dart'
     hide Parse, CoreStoreSembastImp;
 
 part 'src/storage/core_store_sp_impl.dart';
-part 'src/utils/parse_live_list.dart';
 part 'src/utils/parse_live_grid.dart';
+part 'src/utils/parse_live_list.dart';
 
 class Parse extends sdk.Parse
     with WidgetsBindingObserver
@@ -146,7 +146,7 @@ class CoreStoreSembastImp implements sdk.CoreStoreSembastImp {
   static sdk.CoreStoreSembastImp _sembastImp;
 
   static Future<sdk.CoreStore> getInstance(
-      {DatabaseFactory factory, String password}) async {
+      {DatabaseFactory factory, String password = 'flutter_sdk'}) async {
     if (_sembastImp == null) {
       String dbDirectory = '';
       if (!sdk.parseIsWeb &&

--- a/packages/flutter/lib/parse_server_sdk.dart
+++ b/packages/flutter/lib/parse_server_sdk.dart
@@ -51,7 +51,7 @@ class Parse extends sdk.Parse
     String clientKey,
     String masterKey,
     String sessionId,
-    bool autoSendSessionId,
+    bool autoSendSessionId = true,
     SecurityContext securityContext,
     sdk.CoreStore coreStore,
     Map<String, sdk.ParseObjectConstructor> registeredSubClassMap,

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 2.0.1
+version: 2.1.0
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -25,12 +25,12 @@ dependencies:
 
   # Utils
   path_provider: ^1.6.27 # only used in the flutter part
-  package_info: ^0.4.3+2 # only used in the flutter part
-  sembast: ^2.4.8+1 # required for transitive use only
+  package_info: ^0.4.3+4 # only used in the flutter part
+  sembast: ^2.4.9 # required for transitive use only
   path: ^1.7.0 # required for transitive use only
 
 dev_dependencies:
   # Testing
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.3
+  mockito: ^4.1.4

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -18,19 +18,19 @@ dependencies:
 
   # Networking
   dio: ^3.0.10
-  connectivity: ^0.4.9+2 # only used in the flutter part
+  connectivity: ^2.0.2 # only used in the flutter part
 
   #Database
-  shared_preferences: ^0.5.10 # only used in the flutter part
+  shared_preferences: ^0.5.12+4 # only used in the flutter part
 
   # Utils
-  path_provider: ^1.6.14 # only used in the flutter part
-  package_info: ^0.4.3 # only used in the flutter part
-  sembast: ^2.4.7+6 # required for transitive use only
+  path_provider: ^1.6.27 # only used in the flutter part
+  package_info: ^0.4.3+2 # only used in the flutter part
+  sembast: ^2.4.8+1 # required for transitive use only
   path: ^1.7.0 # required for transitive use only
 
 dev_dependencies:
   # Testing
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.1
+  mockito: ^4.1.3


### PR DESCRIPTION
* Fix CoreStoreSembastImp with no default passwod causes error in Flutter Package
* Fix ParseACL with no default value in setReadAccess and setWriteAccess
* Add method excludeKeys: Exclude specific fields from the returned query
* Updated Dependencies version in pubspec.yaml
* Fix typo in the ParseConnectivity provided Error message parse_live_query.dart