### PR TITLE
Fix LiveQuery: wont add element to empty list

### DIFF
--- a/packages/dart/lib/parse_server_sdk.dart
+++ b/packages/dart/lib/parse_server_sdk.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:dio/dio.dart' hide Options;
 import 'package:meta/meta.dart';
 import 'package:mime_type/mime_type.dart';
 import 'package:parse_server_sdk/src/network/parse_http_client.dart';


### PR DESCRIPTION
Version 2.1.0 has a bug, where new rows won't be added to an empty list.

This occurred, as the animated list was not build in case of an empty list. Resulting in `_animatedListKey.currentState` being null. By using a stack to view both widgets, this should be fixed without any side effects.

The `queryEmptyElement` is now also animated.