### PR TITLE
Update parse_base.dart

### DIFF
--- a/packages/dart/lib/src/objects/parse_base.dart
+++ b/packages/dart/lib/src/objects/parse_base.dart
@@ -131,7 +131,7 @@ abstract class ParseBase {
       } else if (key == keyVarObjectId) {
         _getObjectData()[keyVarObjectId] = value;
       } else if (key == keyVarCreatedAt) {
-        if (keyVarCreatedAt is String) {
+        if (value is String) {
           _getObjectData()[keyVarCreatedAt] = _parseDateFormat.parse(value);
         } else {
           _getObjectData()[keyVarCreatedAt] = value;


### PR DESCRIPTION
Fixes a TypeError thrown when parsing an object if it's createdAt property is not a String.