### PR TITLE
:bug: containsKey on wrong key

### DIFF
--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -474,7 +474,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         handleResponse<ParseUser>(user, response, type, debug, className);
 
     final Map<String, dynamic> responseData = jsonDecode(response.data);
-    if (responseData.containsKey(keyVarObjectId)) {
+    if (responseData.containsKey(keyParamSessionToken)) {
       user.sessionToken = responseData[keyParamSessionToken];
       ParseCoreData().setSessionId(user.sessionToken);
     }

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -444,19 +444,20 @@ class ParseUser extends ParseObject implements ParseCloneable {
       return handleException(e, ParseApiRQ.getAll, _debug, keyClassUser);
     }
   }
-
   static Future<dynamic> _getUserFromLocalStore(
-      {ParseCloneable cloneable}) async {
+      {ParseCloneable? cloneable}) async {
     final CoreStore coreStore = ParseCoreData().getStore();
-    final String userJson = await coreStore.getString(keyParseStoreUser);
+    final String? userJson = await coreStore.getString(keyParseStoreUser);
 
     if (userJson != null) {
       final Map<String, dynamic> userMap = json.decode(userJson);
       if (cloneable != null) {
         return cloneable.clone(userMap);
       } else {
-        ParseCoreData().setSessionId(userMap[keyParamSessionToken]);
-        return parseDecode(userMap);
+        if (userMap.containsKey(keyParamSessionToken)) {
+          ParseCoreData().setSessionId(userMap[keyParamSessionToken]);
+          return parseDecode(userMap);
+        }
       }
     }
 


### PR DESCRIPTION
The containsKey check is on the wrong key (keyVarObjectId) instead of (keyParamSessionToken) - therefore it fails on null safety, if the sessionToken is not provided in responseData (for example in case of signUp)