### PR TITLE
LiveList/LiveQuery nullsafety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   - (cd packages/dart && pub get)
   - (cd packages/dart && dart run build_runner build --delete-conflicting-outputs)
   - (cd packages/dart && pub run test)
+  - (cd packages/flutter && flutter pub remove parse_server_sdk)
+  - (cd packages/flutter && flutter pub add parse_server_sdk --path ../dart)
   - (cd packages/flutter && flutter pub get)
   - (cd packages/flutter && flutter test --no-pub test/)
 

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.0.0';
+const String keySdkVersion = '3.0.1';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.0.1';
+const String keySdkVersion = '3.1.0';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -154,9 +154,11 @@ class LiveQueryClient {
         liveQueryURL = liveQueryURL.replaceAll('http', 'ws');
       }
     }
-    _instance ??= LiveQueryClient._internal(liveQueryURL,
-        debug: debug, autoSendSessionId: autoSendSessionId);
-    return _instance!;
+    LiveQueryClient instance = _instance ??
+        LiveQueryClient._internal(liveQueryURL,
+            debug: debug, autoSendSessionId: autoSendSessionId);
+    _instance ??= instance;
+    return instance;
   }
 
   Stream<LiveQueryClientEvent> get getClientEventStream {

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -61,8 +61,9 @@ class LiveQueryReconnectingController {
           break;
         case LiveQueryClientEvent.USER_DISCONNECTED:
           _userDisconnected = true;
-          if (_currentTimer != null) {
-            _currentTimer!.cancel();
+          Timer? currentTimer = _currentTimer;
+          if (currentTimer != null) {
+            currentTimer.cancel();
             _currentTimer = null;
           }
           break;

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -347,7 +347,7 @@ class LiveQueryClient {
       'op': 'subscribe',
       'requestId': subscription.requestId,
       'query': <String, dynamic>{
-        'className': query.object!.parseClassName,
+        'className': query.object.parseClassName,
         'where': _whereMap,
         if (keysToReturn != null && keysToReturn.isNotEmpty)
           'fields': keysToReturn

--- a/packages/dart/lib/src/network/parse_query.dart
+++ b/packages/dart/lib/src/network/parse_query.dart
@@ -5,8 +5,9 @@ class QueryBuilder<T extends ParseObject> {
   /// Class to create complex queries
   QueryBuilder(this.object) : super();
 
-  QueryBuilder.name(String classname)
-      : this(ParseCoreData.instance.createObject(classname) as T?);
+  factory QueryBuilder.name(String classname) {
+    return QueryBuilder(ParseCoreData.instance.createObject(classname) as T);
+  }
 
   QueryBuilder.or(this.object, List<QueryBuilder<T>> list) {
     String query = '"\$or":[';
@@ -20,20 +21,21 @@ class QueryBuilder<T extends ParseObject> {
     queries.add(MapEntry<String, dynamic>(_NO_OPERATOR_NEEDED, query));
   }
 
-  QueryBuilder.copy(QueryBuilder<T> query) {
-    object = query.object;
-    queries = query.queries
+  factory QueryBuilder.copy(QueryBuilder<T> query) {
+    QueryBuilder<T> copy = QueryBuilder(query.object);
+    copy.queries = query.queries
         .map((MapEntry<String, dynamic> entry) =>
             MapEntry<String, dynamic>(entry.key, entry.value.toString()))
         .toList();
     query.limiters.forEach((String key, dynamic value) =>
-        limiters.putIfAbsent(key, () => value.toString()));
+        copy.limiters.putIfAbsent(key, () => value.toString()));
+    return copy;
   }
 
   static const String _NO_OPERATOR_NEEDED = 'NO_OP';
   static const String _SINGLE_QUERY = 'SINGLE_QUERY';
 
-  T? object;
+  T object;
   List<MapEntry<String, dynamic>> queries = <MapEntry<String, dynamic>>[];
   final Map<String, dynamic> limiters = Map<String, dynamic>();
 
@@ -284,18 +286,20 @@ class QueryBuilder<T extends ParseObject> {
   }
 
   // Add a constraint to the query that requires a particular key's value match another QueryBuilder
-  void whereMatchesQuery<E extends ParseObject>(String column, QueryBuilder<E> query) {
+  void whereMatchesQuery<E extends ParseObject>(
+      String column, QueryBuilder<E> query) {
     final String inQuery =
-        query._buildQueryRelational(query.object!.parseClassName);
+        query._buildQueryRelational(query.object.parseClassName);
 
     queries.add(MapEntry<String, dynamic>(
         _SINGLE_QUERY, '\"$column\":{\"\$inQuery\":$inQuery}'));
   }
 
   //Add a constraint to the query that requires a particular key's value does not match another QueryBuilder
-  void whereDoesNotMatchQuery<E extends ParseObject>(String column, QueryBuilder<E> query) {
+  void whereDoesNotMatchQuery<E extends ParseObject>(
+      String column, QueryBuilder<E> query) {
     final String inQuery =
-        query._buildQueryRelational(query.object!.parseClassName);
+        query._buildQueryRelational(query.object.parseClassName);
 
     queries.add(MapEntry<String, dynamic>(
         _SINGLE_QUERY, '\"$column\":{\"\$notInQuery\":$inQuery}'));
@@ -315,7 +319,7 @@ class QueryBuilder<T extends ParseObject> {
     }
 
     final String inQuery =
-        query._buildQueryRelationalKey(query.object!.parseClassName, keyInQuery);
+        query._buildQueryRelationalKey(query.object.parseClassName, keyInQuery);
 
     queries.add(MapEntry<String, dynamic>(
         _SINGLE_QUERY, '\"$column\":{\"\$select\":$inQuery}'));
@@ -335,7 +339,7 @@ class QueryBuilder<T extends ParseObject> {
     }
 
     final String inQuery =
-        query._buildQueryRelationalKey(query.object!.parseClassName, keyInQuery);
+        query._buildQueryRelationalKey(query.object.parseClassName, keyInQuery);
 
     queries.add(MapEntry<String, dynamic>(
         _SINGLE_QUERY, '\"$column\":{\"\$dontSelect\":$inQuery}'));
@@ -346,7 +350,7 @@ class QueryBuilder<T extends ParseObject> {
   /// Make sure to call this after defining your queries
   Future<ParseResponse> query<T extends ParseObject>(
       {ProgressCallback? progressCallback}) async {
-    return object!.query<T>(
+    return object.query<T>(
       buildQuery(),
       progressCallback: progressCallback,
     );
@@ -355,12 +359,12 @@ class QueryBuilder<T extends ParseObject> {
   Future<ParseResponse> distinct<T extends ParseObject>(
       String className) async {
     final String queryString = 'distinct=$className';
-    return object!.distinct<T>(queryString);
+    return object.distinct<T>(queryString);
   }
 
   ///Counts the number of objects that match this query
   Future<ParseResponse> count() async {
-    return object!.query(_buildQueryCount());
+    return object.query(_buildQueryCount());
   }
 
   /// Builds the query for Parse

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -590,11 +590,12 @@ class ParseLiveListElement<T extends ParseObject> {
 
   void _subscribe() {
     _subscriptionQueue.whenComplete(() async {
-      if (_updatedSubItems.isNotEmpty && _object != null) {
+      T? object = _object;
+      if (_updatedSubItems.isNotEmpty && object != null) {
         final List<Future<void>> tasks = <Future<void>>[];
         for (PathKey key in _updatedSubItems.keys) {
-          tasks.add(_subscribeSubItem(_object!, key,
-              _object!.get<ParseObject>(key.key)!, _updatedSubItems[key]));
+          tasks.add(_subscribeSubItem(object, key,
+              object.get<ParseObject>(key.key), _updatedSubItems[key]));
         }
         await Future.wait(tasks);
       }
@@ -612,12 +613,12 @@ class ParseLiveListElement<T extends ParseObject> {
   }
 
   Future<void> _subscribeSubItem(ParseObject parentObject, PathKey currentKey,
-      ParseObject subObject, Map<PathKey, dynamic> path) async {
-    if (_liveQuery != null) {
+      ParseObject? subObject, Map<PathKey, dynamic> path) async {
+    if (_liveQuery != null && subObject != null) {
       final List<Future<void>> tasks = <Future<void>>[];
       for (PathKey key in path.keys) {
         tasks.add(_subscribeSubItem(
-            subObject, key, subObject.get<ParseObject>(key.key)!, path[key]));
+            subObject, key, subObject.get<ParseObject>(key.key), path[key]));
       }
       final QueryBuilder<ParseObject> queryBuilder =
           QueryBuilder<ParseObject>(subObject)
@@ -641,7 +642,7 @@ class ParseLiveListElement<T extends ParseObject> {
               _unsubscribe(path);
               for (PathKey key in path.keys) {
                 tasks.add(_subscribeSubItem(newObject, key,
-                    newObject.get<ParseObject>(key.key)!, path[key]));
+                    newObject.get<ParseObject>(key.key), path[key]));
               }
             }
             await Future.wait(tasks);

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -778,9 +778,6 @@ class ParseLiveListDeleteEvent<T extends ParseObject>
   ParseLiveListDeleteEvent(int index, T object) : super(index, object);
 }
 
-typedef StreamGetter<T extends ParseObject> = Stream<T> Function();
-typedef DataGetter<T extends ParseObject> = T Function();
-
 class ParseLiveListElementSnapshot<T extends ParseObject> {
   ParseLiveListElementSnapshot(
       {this.loadedData, this.error, this.preLoadedData});

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -165,7 +165,7 @@ class ParseLiveList<T extends ParseObject> {
     LiveQuery()
         .client
         .subscribe<T>(QueryBuilder<T>.copy(_query),
-            copyObject: _query.object!.clone(_query.object!.toJson()))
+            copyObject: _query.object.clone(_query.object.toJson()))
         .then((Subscription<T> subscription) {
       _liveQuerySubscription = subscription;
 
@@ -266,7 +266,7 @@ class ParseLiveList<T extends ParseObject> {
     for (String key in paths.keys) {
       if (object.containsKey(key)) {
         ParseObject? includedObject = object.get<ParseObject>(key);
-        if(includedObject != null){
+        if (includedObject != null) {
           //If the object is not fetched
           if (!includedObject.containsKey(keyVarUpdatedAt)) {
             //See if oldObject contains key

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -375,11 +375,13 @@ class ParseLiveList<T extends ParseObject> {
 
   Future<void> _objectUpdated(T object) async {
     for (int i = 0; i < _list.length; i++) {
-      if (_list[i].object!.get<String>(keyVarObjectId) ==
-          object.get<String>(keyVarObjectId)) {
+      T? other = _list[i].object;
+      if (other != null &&
+          other.get<String>(keyVarObjectId) ==
+              object.get<String>(keyVarObjectId)) {
         await _loadIncludes(object,
             oldObject: _list[i].object, paths: _includePaths);
-        if (after(_list[i].object, object) == null) {
+        if (after(other, object) == null) {
           _list[i].object = object.clone(object.toJson(full: true));
           _eventStreamController.sink.add(ParseLiveListUpdateEvent<T>(
               i, object.clone(object.toJson(full: true))));

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -614,7 +614,8 @@ class ParseLiveListElement<T extends ParseObject> {
 
   Future<void> _subscribeSubItem(ParseObject parentObject, PathKey currentKey,
       ParseObject? subObject, Map<PathKey, dynamic> path) async {
-    if (_liveQuery != null && subObject != null) {
+    LiveQuery? liveQuery = _liveQuery;
+    if (liveQuery != null && subObject != null) {
       final List<Future<void>> tasks = <Future<void>>[];
       for (PathKey key in path.keys) {
         tasks.add(_subscribeSubItem(
@@ -624,7 +625,7 @@ class ParseLiveListElement<T extends ParseObject> {
           QueryBuilder<ParseObject>(subObject)
             ..whereEqualTo(keyVarObjectId, subObject.objectId);
 
-      tasks.add(_liveQuery!.client
+      tasks.add(liveQuery.client
           .subscribe(queryBuilder)
           .then((Subscription<ParseObject> subscription) {
         currentKey.subscription = subscription;

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -133,7 +133,7 @@ class ParseLiveList<T extends ParseObject> {
     if (_debug)
       print('ParseLiveList: lazyLoading is ${_lazyLoading ? 'on' : 'off'}');
     if (_lazyLoading) {
-      final List<String> keys = _preloadedColumns;
+      final List<String> keys = _preloadedColumns.toList();
       if (_lazyLoading && query.limiters.containsKey('order'))
         keys.addAll(
           query.limiters['order'].toString().split(',').map((String string) {
@@ -480,12 +480,11 @@ class ParseLiveList<T extends ParseObject> {
 }
 
 class ParseLiveElement<T extends ParseObject> extends ParseLiveListElement<T> {
-  ParseLiveElement(T object,
-      {bool loaded = false, List<String>? includeObject})
+  ParseLiveElement(T object, {bool loaded = false, List<String>? includeObject})
       : super(object,
-      loaded: loaded,
-      updatedSubItems:
-      ParseLiveList._toIncludeMap(includeObject ?? <String>[])) {
+            loaded: loaded,
+            updatedSubItems:
+                ParseLiveList._toIncludeMap(includeObject ?? <String>[])) {
     _includes = ParseLiveList._toIncludeMap(includeObject ?? <String>[]);
     queryBuilder = QueryBuilder<T>(object.clone(<String, dynamic>{}))
       ..whereEqualTo(keyVarObjectId, object.objectId);

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -308,9 +308,11 @@ class ParseLiveList<T extends ParseObject> {
                   ParseObject>(ParseObject(includedObject.parseClassName))
                 ..whereEqualTo(keyVarObjectId, includedObject.objectId)
                 ..includeObject(_toIncludeStringList(paths[key]));
-              loadingNodes.add(
-                  queryBuilder.query().then<void>((ParseResponse parseResponse) {
-                if (parseResponse.success && parseResponse.results!.length == 1) {
+              loadingNodes.add(queryBuilder
+                  .query()
+                  .then<void>((ParseResponse parseResponse) {
+                if (parseResponse.success &&
+                    parseResponse.results!.length == 1) {
                   // ignore: deprecated_member_use_from_same_package
                   object[key] = parseResponse.results![0];
                 }
@@ -445,7 +447,7 @@ class ParseLiveList<T extends ParseObject> {
   String getIdentifier(int index) {
     if (index < _list.length) {
       return _list[index].object!.get<String>(keyVarObjectId)! +
-              _list[index].object!.get<DateTime>(keyVarUpdatedAt).toString();
+          _list[index].object!.get<DateTime>(keyVarUpdatedAt).toString();
     }
     return 'NotFound';
   }

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -44,8 +44,7 @@ class ParseLiveList<T extends ParseObject> {
   int get nextID => _nextID++;
 
   /// is object1 listed after object2?
-  /// can return null
-  bool? after(T? object1, T? object2) {
+  bool? after(T object1, T object2) {
     List<String> fields = <String>[];
 
     if (_query.limiters.containsKey('order')) {
@@ -58,8 +57,8 @@ class ParseLiveList<T extends ParseObject> {
         reverse = true;
         key = key.substring(1);
       }
-      final dynamic val1 = object1!.get<dynamic>(key);
-      final dynamic val2 = object2!.get<dynamic>(key);
+      final dynamic val1 = object1.get<dynamic>(key);
+      final dynamic val2 = object2.get<dynamic>(key);
 
       if (val1 == null && val2 == null) {
         break;
@@ -357,7 +356,8 @@ class ParseLiveList<T extends ParseObject> {
       await _loadIncludes(object, paths: _includePaths);
     }
     for (int i = 0; i < _list.length; i++) {
-      if (after(object, _list[i].object) != true) {
+      T? other = _list[i].object;
+      if (other != null && after(object, other) != true) {
         _list.insert(
             i,
             ParseLiveListElement<T>(object,

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,13 +1,12 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-
   # Networking
   dio: ^4.0.0
   http: ^0.13.1

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -14,7 +14,7 @@ This is a work in progress and we are consistently updating it. Please let us kn
 To install, either add to your pubspec.yaml
 ```yml
 dependencies:  
-    parse_server_sdk_flutter: ^3.0.0
+    parse_server_sdk_flutter: ^3.0.1
 ```
 or clone this repository and add to your project. As this is an early development with multiple contributors, it is probably best to download/clone and keep updating as an when a new feature is added.
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -14,7 +14,7 @@ This is a work in progress and we are consistently updating it. Please let us kn
 To install, either add to your pubspec.yaml
 ```yml
 dependencies:  
-    parse_server_sdk_flutter: ^3.0.1
+    parse_server_sdk_flutter: ^3.1.0
 ```
 or clone this repository and add to your project. As this is an early development with multiple contributors, it is probably best to download/clone and keep updating as an when a new feature is added.
 

--- a/packages/flutter/lib/src/utils/parse_live_list.dart
+++ b/packages/flutter/lib/src/utils/parse_live_list.dart
@@ -3,6 +3,9 @@ part of flutter_parse_sdk_flutter;
 typedef ChildBuilder<T extends sdk.ParseObject> = Widget Function(
     BuildContext context, sdk.ParseLiveListElementSnapshot<T> snapshot);
 
+typedef StreamGetter<T extends sdk.ParseObject> = Stream<T> Function();
+typedef DataGetter<T extends sdk.ParseObject> = T Function();
+
 class ParseLiveListWidget<T extends sdk.ParseObject> extends StatefulWidget {
   const ParseLiveListWidget({
     Key? key,
@@ -211,9 +214,9 @@ class ParseLiveListElementWidget<T extends sdk.ParseObject>
       required this.childBuilder})
       : super(key: key);
 
-  final sdk.StreamGetter<T>? stream;
-  final sdk.DataGetter<T>? loadedData;
-  final sdk.DataGetter<T>? preLoadedData;
+  final StreamGetter<T>? stream;
+  final DataGetter<T>? loadedData;
+  final DataGetter<T>? preLoadedData;
   final Animation<double> sizeFactor;
   final Duration duration;
   final ChildBuilder<T> childBuilder;
@@ -228,8 +231,8 @@ class ParseLiveListElementWidget<T extends sdk.ParseObject>
 class _ParseLiveListElementWidgetState<T extends sdk.ParseObject>
     extends State<ParseLiveListElementWidget<T>>
     with SingleTickerProviderStateMixin {
-  _ParseLiveListElementWidgetState(sdk.DataGetter<T>? loadedDataGetter,
-      sdk.DataGetter<T>? preLoadedDataGetter, sdk.StreamGetter<T>? stream) {
+  _ParseLiveListElementWidgetState(DataGetter<T>? loadedDataGetter,
+      DataGetter<T>? preLoadedDataGetter, StreamGetter<T>? stream) {
     _snapshot = sdk.ParseLiveListElementSnapshot<T>(
         loadedData: loadedDataGetter != null ? loadedDataGetter() : null,
         preLoadedData:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # Uncomment for Release version
-  parse_server_sdk:   ^3.0.0
+  parse_server_sdk:   ^3.0.1
 
   # Uncomment for local testing
   #parse_server_sdk:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # Uncomment for Release version
-  parse_server_sdk:   ^3.0.1
+  parse_server_sdk: ^3.1.0
 
   # Uncomment for local testing
   #parse_server_sdk:


### PR DESCRIPTION
**TLDR:** No new features, just fixes arround the ParseLiveList.


While migrating my app, I've noticed LiveList has been broken due to the null-safety migration. I've decided to go through the entire LiveQuery and LiveList part in order to remove those not-null casts (`something!`).

Additionally I've [changed](https://github.com/parse-community/Parse-SDK-Flutter/commit/d5223d13c81639d2b09b39618288ec4ee4f91a94) `object` in `QueryBuilder` from nullable to not-nullable. In theory this is a breaking change, as we formally allowed null as the argument in the default constructor before. But as setting it to null would result in a crash, I think we should be fine with updating the version number to just "3.0.1".

Close #612