### PR TITLE
fixes #653

### DIFF
--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -31,6 +31,7 @@ class ParseLiveList<T extends ParseObject> {
   }
 
   final QueryBuilder<T> _query;
+
   //The included Items, where LiveList should look for updates.
   final Map<String, dynamic> _listeningIncludes;
   final bool _lazyLoading;
@@ -142,7 +143,7 @@ class ParseLiveList<T extends ParseObject> {
             return string;
           }),
         );
-      query.keysToReturn(keys);
+      if (keys.isNotEmpty) query.keysToReturn(keys);
     }
     return await query.query<T>();
   }
@@ -738,6 +739,7 @@ class PathKey {
 
   final String key;
   Subscription<ParseObject>? subscription;
+
   @override
   String toString() {
     return 'PathKey(key: $key, subscription: ${subscription?.requestId})';


### PR DESCRIPTION
ParseLiveListWidget is sending the wrong GET request if lazyloading is enabled and no order limiter is set.
We have to check if there is a key to send