### PR TITLE
ci: add manual release workflow

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,44 +1,31 @@
+# Trigger this workflow to manually create a release of the flutter package.
+
 name: release-manual
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Reference (tag / SHA):'
+        required: true
+        default: ''
+      package:
+        description: 'Package'
+        required: true
+        default: ''
+        type: choice
+        options:
+        - dart
+        - flutter
 jobs:
-  # dry-run:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     dart_dry_run_success: ${{ steps.try-dart.outputs.success }}
-  #     flutter_dry_run_success: ${{ steps.try-flutter.outputs.success }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v3
-  #     - name: Dry run dart package
-  #       uses: k-paxian/dart-package-publisher@v1.4
-  #       id: try-dart
-  #       with:
-  #         accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-  #         refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-  #         relativePath: packages/dart
-  #         format: true
-  #         dryRunOnly: true
-  #     - name: Dry run flutter package
-  #       uses: k-paxian/dart-package-publisher@v1.4
-  #       id: try-flutter
-  #       with:
-  #         accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-  #         refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-  #         relativePath: packages/flutter
-  #         flutter: true
-  #         format: true
-  #         dryRunOnly: true
   release:
     runs-on: ubuntu-latest
-    # needs: dry-run
-    # if: needs.dry-run.outputs.dart_dry_run_success && needs.dry-run.outputs.flutter_dry_run_success
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref }}
       - name: Publish dart package
+        if: github.event.inputs.package == 'dart'
         uses: k-paxian/dart-package-publisher@v1.4
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
@@ -47,6 +34,7 @@ jobs:
           format: true
           dryRunOnly: true
       - name: Publish flutter package
+        if: github.event.inputs.package == 'flutter'
         uses: k-paxian/dart-package-publisher@v1.4
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -1,0 +1,57 @@
+name: release-trigger
+on:
+  release:
+    types:
+      - published
+jobs:
+  # dry-run:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     dart_dry_run_success: ${{ steps.try-dart.outputs.success }}
+  #     flutter_dry_run_success: ${{ steps.try-flutter.outputs.success }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v3
+  #     - name: Dry run dart package
+  #       uses: k-paxian/dart-package-publisher@v1.4
+  #       id: try-dart
+  #       with:
+  #         accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
+  #         refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
+  #         relativePath: packages/dart
+  #         format: true
+  #         dryRunOnly: true
+  #     - name: Dry run flutter package
+  #       uses: k-paxian/dart-package-publisher@v1.4
+  #       id: try-flutter
+  #       with:
+  #         accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
+  #         refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
+  #         relativePath: packages/flutter
+  #         flutter: true
+  #         format: true
+  #         dryRunOnly: true
+  release:
+    runs-on: ubuntu-latest
+    # needs: dry-run
+    # if: needs.dry-run.outputs.dart_dry_run_success && needs.dry-run.outputs.flutter_dry_run_success
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Publish dart package
+        uses: k-paxian/dart-package-publisher@v1.4
+        with:
+          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
+          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
+          relativePath: packages/dart
+          format: true
+          dryRunOnly: true
+      - name: Publish flutter package
+        uses: k-paxian/dart-package-publisher@v1.4
+        with:
+          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
+          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
+          relativePath: packages/flutter
+          flutter: true
+          format: true
+          dryRunOnly: true


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
Add manual release workflow per package.

Related issue: #668 

### Approach
Add workflow that requests tag + package input to trigger the appropriate publishing process.

### TODOs before merging
n/a