### PR TITLE
ci: bump versions for next release

### DIFF
--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.1
+version: 3.1.2
 homepage: https://github.com/phillwiggins/flutter_parse_sdk
 
 environment:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # Uncomment for Release version
-  parse_server_sdk: ^3.1.0
+  parse_server_sdk: ^3.1.1
 
   # Uncomment for local testing
   #parse_server_sdk:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
Bumping the versions, since #734 did not cover it.

Related issue: #733 

### Approach
~Left the `parse_server_sdk` dependency in the flutter package at `^3.1.0`.~

Not sure if the title really fits. Feel free to edit. `ci:` seems best to me.

### TODOs before merging
n/a