### PR TITLE
ci: add auto-release

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,33 +1,15 @@
-# Trigger this workflow only to manually create a dart/flutter release; this should only be used
-# in extraordinary circumstances, as dart/flutter releases are normally created automatically as
-# part of the automated release workflow.
-
-name: release-manual
+name: release-automated
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Reference (tag / SHA):'
-        required: true
-        default: ''
-      package:
-        description: 'Package'
-        required: true
-        default: ''
-        type: choice
-        options:
-        - dart
-        - flutter
+  release:
+    types: [created]
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.ref }}
       - name: Publish dart package
-        if: github.event.inputs.package == 'dart'
+        if: ${{ startsWith(github.ref_name, 'dart') }}
         uses: k-paxian/dart-package-publisher@v1.4
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
@@ -36,7 +18,7 @@ jobs:
           format: true
           dryRunOnly: false
       - name: Publish flutter package
-        if: github.event.inputs.package == 'flutter'
+        if: ${{ startsWith(github.ref_name, 'flutter') }}
         uses: k-paxian/dart-package-publisher@v1.4
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
After manually creating a release, publishing to the pub.dev registry is an additional manual step.

Related issue: #668 

### Approach
Autoamtically triggers the release workflow after creating a release.
The package to publish is determined by the created tag:
- `dart-#.#.#` -> publish dart package
- `flutter-#.#.#` -> publish flutter package

### TODOs before merging
n/a