### PR TITLE
fix: query fails for subclassed Parse object in Parse relation

### DIFF
--- a/packages/dart/lib/src/objects/parse_relation.dart
+++ b/packages/dart/lib/src/objects/parse_relation.dart
@@ -29,7 +29,7 @@ class ParseRelation<T extends ParseObject> {
   Set<T>? _knownObjects = <T>{};
 
   QueryBuilder getQuery() {
-    return QueryBuilder(ParseObject(_targetClass!))
+    return QueryBuilder(ParseCoreData.instance.createObject(_targetClass!))
       ..whereRelatedTo(_key, _parent!.parseClassName, _parentObjectId);
   }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #696

### Approach
Due to the deletion of the development branch #697 was closed automatically.
I've decided to cherry pick 4829c367ba09e3bd75184f48a8d81cf81e8c83e8 and (re-)open the PR to avoid loosing a contribution.

**This change is not tested by me.** *Since I didn't use relations yet.*

CC: @kutear

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
