### PR TITLE
fix: the Response from DioError could return null from the data property but String is expected in ParseNetworkResponse

### DIFF
--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -31,7 +31,9 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 
@@ -51,7 +53,9 @@ class ParseDioClient extends ParseClient {
           bytes: dioResponse.data, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkByteResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 
@@ -68,7 +72,9 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 
@@ -85,7 +91,9 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 
@@ -105,7 +113,9 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 
@@ -121,7 +131,9 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? 'NetworkError',
+        statusCode: error.response!.statusCode!,
+      );
     }
   }
 }

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -31,7 +31,7 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
@@ -53,7 +53,7 @@ class ParseDioClient extends ParseClient {
           bytes: dioResponse.data, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkByteResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
@@ -72,7 +72,7 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
@@ -91,7 +91,7 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
@@ -113,7 +113,7 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
@@ -131,11 +131,13 @@ class ParseDioClient extends ParseClient {
           data: dioResponse.data!, statusCode: dioResponse.statusCode!);
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-        data: error.response?.data ?? 'NetworkError',
+        data: error.response?.data ?? _fallbackErrorData,
         statusCode: error.response!.statusCode!,
       );
     }
   }
+
+  String get _fallbackErrorData => '{$keyError:NetworkError}';
 }
 
 /// Creates a custom version of HTTP Client that has Parse Data Preset

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -137,7 +137,7 @@ class ParseDioClient extends ParseClient {
     }
   }
 
-  String get _fallbackErrorData => '{$keyError:NetworkError}';
+  String get _fallbackErrorData => '{"$keyError":"NetworkError"}';
 }
 
 /// Creates a custom version of HTTP Client that has Parse Data Preset

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.2...flutter-3.1.3) (2022-07-01)
+## [3.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.2...flutter-3.1.3) (2022-07-07)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues/774).

### Issue Description
The response from `dio` error object could have a null `data` property

Related issue: https://github.com/parse-community/Parse-SDK-Flutter/issues/774

### Approach
Add null aware operator `??`:
```
on dio.DioError catch (error) {
      return ParseNetworkByteResponse(
        data: error.response?.data ?? _fallbackErrorData,
        statusCode: error.response!.statusCode!,
      );
    }
```

### TODOs before merging
All set

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
