### PR TITLE
fix: skip warning pub.dev for web

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -36,3 +36,19 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.2.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        default_package: parse_server_sdk_flutter
+      ios:
+        default_package: parse_server_sdk_flutter
+      linux:
+        default_package: parse_server_sdk_flutter
+      macos:
+        default_package: parse_server_sdk_flutter
+      web:
+        default_package: parse_server_sdk_flutter
+      windows:
+        default_package: parse_server_sdk_flutter


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
The response from skip warning pub.dev for web

Related issue: https://github.com/parse-community/Parse-SDK-Flutter/issues/781

### Approach
Added some flutter code to skip warnings

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
