### PR TITLE
fix: Custom JSON encoder for List and Map doesn't work correctly in `full` mode

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.2...dart-3.1.3) (2022-11-15)
+
+### Bug Fixes
+
+* Custom JSON encoder for List and Map doesn't work correctly in `full` mode ([#788](https://github.com/parse-community/Parse-SDK-Flutter/issues/788))
+
 ## [3.1.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.1...dart-3.1.2) (2022-07-09)
 
 ### Bug Fixes

--- a/packages/dart/lib/src/utils/parse_encoder.dart
+++ b/packages/dart/lib/src/utils/parse_encoder.dart
@@ -20,7 +20,7 @@ dynamic parseEncode(dynamic value, {bool full = false}) {
 
   if (value is List) {
     return value.map<dynamic>((dynamic value) {
-      return parseEncode(value, full: full);
+      return parseEncode(value, full);
     }).toList();
   }
 

--- a/packages/dart/lib/src/utils/parse_encoder.dart
+++ b/packages/dart/lib/src/utils/parse_encoder.dart
@@ -20,7 +20,7 @@ dynamic parseEncode(dynamic value, {bool full = false}) {
 
   if (value is List) {
     return value.map<dynamic>((dynamic value) {
-      return parseEncode(value, full);
+      return parseEncode(value, full: full);
     }).toList();
   }
 

--- a/packages/dart/lib/src/utils/parse_encoder.dart
+++ b/packages/dart/lib/src/utils/parse_encoder.dart
@@ -20,13 +20,13 @@ dynamic parseEncode(dynamic value, {bool full = false}) {
 
   if (value is List) {
     return value.map<dynamic>((dynamic value) {
-      return parseEncode(value);
+      return parseEncode(value, full: full);
     }).toList();
   }
 
   if (value is Map) {
     value.forEach((dynamic k, dynamic v) {
-      value[k] = parseEncode(v);
+      value[k] = parseEncode(v, full: full);
     });
   }
 

--- a/packages/dart/lib/src/utils/parse_encoder.dart
+++ b/packages/dart/lib/src/utils/parse_encoder.dart
@@ -26,7 +26,7 @@ dynamic parseEncode(dynamic value, {bool full = false}) {
 
   if (value is Map) {
     value.forEach((dynamic k, dynamic v) {
-      value[k] = parseEncode(v, full);
+      value[k] = parseEncode(v, full: full);
     });
   }
 

--- a/packages/dart/lib/src/utils/parse_encoder.dart
+++ b/packages/dart/lib/src/utils/parse_encoder.dart
@@ -26,7 +26,7 @@ dynamic parseEncode(dynamic value, {bool full = false}) {
 
   if (value is Map) {
     value.forEach((dynamic k, dynamic v) {
-      value[k] = parseEncode(v, full: full);
+      value[k] = parseEncode(v, full);
     });
   }
 

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.2
+version: 3.1.3
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/dart/test/parse_encoder_test.dart
+++ b/packages/dart/test/parse_encoder_test.dart
@@ -18,17 +18,11 @@ void main() {
       appVersion: 'someAppVersion',
     );
 
-    String expectedResult =
-        "{className: parseObject1, objectId: objectId1, dataParseObject2: {__op: Add, objects: [{className: objectId2, objectId: objectId2, dataParseObjectList: {__op: Add, objects: [[ListText1, ListText2, ListText3]]}, dataParseObjectMap: {__op: Add, objects: [{KeyTestMap1: ValueTestMap1, KeyTestMap2: ValueTestMap2, KeyTestMap3: ValueTestMap3}]}}]}}";
-
-    // act
     ParseObject parseObject2 = ParseObject("objectId2");
     parseObject2.objectId = "objectId2";
 
-    // list
+    // List and Map
     parseObject2.setAdd("dataParseObjectList", ["ListText1", "ListText2", "ListText3"]);
-
-    // map
     parseObject2.setAdd("dataParseObjectMap", {
       'KeyTestMap1': 'ValueTestMap1',
       'KeyTestMap2': 'ValueTestMap2',
@@ -40,6 +34,11 @@ void main() {
     parseObject1.objectId = "objectId1";
     parseObject1.setAdd("dataParseObject2", parseObject2);
 
+    // desired output
+    String expectedResult =
+        "{className: parseObject1, objectId: objectId1, dataParseObject2: {__op: Add, objects: [{className: objectId2, objectId: objectId2, dataParseObjectList: {__op: Add, objects: [[ListText1, ListText2, ListText3]]}, dataParseObjectMap: {__op: Add, objects: [{KeyTestMap1: ValueTestMap1, KeyTestMap2: ValueTestMap2, KeyTestMap3: ValueTestMap3}]}}]}}";
+
+    // act
     dynamic actualResult = parseEncode(parseObject1, full: true);
 
 

--- a/packages/dart/test/parse_encoder_test.dart
+++ b/packages/dart/test/parse_encoder_test.dart
@@ -1,0 +1,49 @@
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('should return expectedResult json when json has Nested map and list data.', () async {
+    // arrange
+    await Parse().initialize(
+      'appId',
+      'https://test.parse.com',
+      debug: true,
+      // to prevent automatic detection
+      fileDirectory: 'someDirectory',
+      // to prevent automatic detection
+      appName: 'appName',
+      // to prevent automatic detection
+      appPackageName: 'somePackageName',
+      // to prevent automatic detection
+      appVersion: 'someAppVersion',
+    );
+
+    String expectedResult =
+        "{className: parseObject1, objectId: objectId1, dataParseObject2: {__op: Add, objects: [{className: objectId2, objectId: objectId2, dataParseObjectList: {__op: Add, objects: [[ListText1, ListText2, ListText3]]}, dataParseObjectMap: {__op: Add, objects: [{KeyTestMap1: ValueTestMap1, KeyTestMap2: ValueTestMap2, KeyTestMap3: ValueTestMap3}]}}]}}";
+
+    // act
+    ParseObject parseObject2 = ParseObject("objectId2");
+    parseObject2.objectId = "objectId2";
+
+    // list
+    parseObject2.setAdd("dataParseObjectList", ["ListText1", "ListText2", "ListText3"]);
+
+    // map
+    parseObject2.setAdd("dataParseObjectMap", {
+      'KeyTestMap1': 'ValueTestMap1',
+      'KeyTestMap2': 'ValueTestMap2',
+      'KeyTestMap3': 'ValueTestMap3',
+    });
+
+    // parseObject2 inside parseObject1
+    ParseObject parseObject1 = ParseObject("parseObject1");
+    parseObject1.objectId = "objectId1";
+    parseObject1.setAdd("dataParseObject2", parseObject2);
+
+    dynamic actualResult = parseEncode(parseObject1, full: true);
+
+
+    //assert
+    expect(actualResult.toString(), expectedResult);
+  });
+}

--- a/packages/dart/test/parse_encoder_test.dart
+++ b/packages/dart/test/parse_encoder_test.dart
@@ -2,7 +2,9 @@ import 'package:parse_server_sdk/parse_server_sdk.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('should return expectedResult json when json has Nested map and list data.', () async {
+  test(
+      'should return expectedResult json when json has Nested map and list data.',
+      () async {
     // arrange
     await Parse().initialize(
       'appId',
@@ -22,7 +24,8 @@ void main() {
     parseObject2.objectId = "objectId2";
 
     // List and Map
-    parseObject2.setAdd("dataParseObjectList", ["ListText1", "ListText2", "ListText3"]);
+    parseObject2
+        .setAdd("dataParseObjectList", ["ListText1", "ListText2", "ListText3"]);
     parseObject2.setAdd("dataParseObjectMap", {
       'KeyTestMap1': 'ValueTestMap1',
       'KeyTestMap2': 'ValueTestMap2',
@@ -40,7 +43,6 @@ void main() {
 
     // act
     dynamic actualResult = parseEncode(parseObject1, full: true);
-
 
     //assert
     expect(actualResult.toString(), expectedResult);


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
Solve the parseEncode problem in list and map
and test added
Related issue: https://github.com/parse-community/Parse-SDK-Flutter/issues/788

### Approach
The ```full: full``` was added for when we use the list and map in parseEncode and toJson

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
