### PR TITLE
feat: Change the database path for IOS from ApplicationDocumentsDirectory to LibraryDirectory

### DIFF
--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -1,11 +1,17 @@
-import 'package:path_provider/path_provider.dart';
+import 'dart:io' show Platform;
+
+import 'package:path_provider/path_provider.dart' as path_provider;
 
 class CoreStoreDirectory {
   Future<String> getDatabaseDirectory() async {
-    return (await getApplicationDocumentsDirectory()).path;
+   if (Platform.isIOS) {
+        return (await path_provider.getLibraryDirectory()).path;
+    } else {
+        return (await path_provider.getApplicationDocumentsDirectory()).path;
+    }
   }
 
   Future<String?> getTempDirectory() async {
-    return (await getTemporaryDirectory()).path;
+    return (await path_provider.getTemporaryDirectory()).path;
   }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #791

### Approach
Using LibraryDirectory as a path for the database.

### TODOs before merging
 This is a breaking change for **_ios_** platform because the SDK now will look for the "parse.db" in the `LibraryDirectory` rather than the `ApplicationDocumentsDirectory`.



- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
