### PR TITLE
fix: Include option in `getObject` feature is not working

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.9](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.8...dart-3.1.9) (2022-12-24)
+
+### Features
+
+* Include option in `getObject` feature is not working ([#813](https://github.com/parse-community/Parse-SDK-Flutter/issues/813))
+
 ## [3.1.8](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.7...dart-3.1.8) (2022-12-23)
 
 ### Features

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.1.9](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.8...dart-3.1.9) (2022-12-24)
+## [3.1.9](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.8...dart-3.1.9) (2022-12-25)
 
 ### Features
 

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.1.8';
+const String keySdkVersion = '3.1.9';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -38,11 +38,13 @@ class ParseObject extends ParseBase implements ParseCloneable {
   Future<ParseResponse> getObject(String objectId,
       {List<String>? include}) async {
     try {
-      String uri = '$_path/$objectId';
+      String? query;
       if (include != null) {
-        uri = '$uri?include=${concatenateArray(include)}';
+        query = 'include=${concatenateArray(include)}';
       }
-      final Uri url = getSanitisedUri(_client, uri);
+
+      final Uri url =
+          getSanitisedUri(_client, '$_path/$objectId', query: query);
 
       final ParseNetworkResponse result = await _client.get(url.toString());
       return handleResponse<ParseObject>(

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.8
+version: 3.1.9
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/dart/test/parse_object_test.dart
+++ b/packages/dart/test/parse_object_test.dart
@@ -98,8 +98,7 @@ void main() {
           objectJsonDesiredOutput);
       expect(parseObject['img'].objectId, "8nGrLj3Mvk");
 
-      expect(Uri.decodeComponent(result.path),
-          '/classes/MyUser/Mn1iJTkWTE?include=img');
+      expect(Uri.decodeComponent(result.query), 'include=img');
     });
 
     test('should return expectedIncludeResult json when use getObject',
@@ -178,8 +177,7 @@ void main() {
           objectJsonDesiredOutput);
       expect(parseObject['img'].objectId, "8nGrLj3Mvk");
 
-      expect(Uri.decodeComponent(result.path),
-          '/classes/MyUser/Mn1iJTkWTE?include=img');
+      expect(Uri.decodeComponent(result.query), 'include=img');
     });
   });
 }


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
fix include in get object

Closes: #813

### Approach
Use Parse SDK built-in functions to solve the problem

### TODOs before merging
- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
