### PR TITLE
fix: `ParseObject.fromJson` does not send proper payload to server

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* fix `fromJson` in ParseBase ([#688](https://github.com/parse-community/Parse-SDK-Flutter/issues/688))
+* `ParseObject.fromJson` does not send proper payload to server ([#688](https://github.com/parse-community/Parse-SDK-Flutter/issues/688))
 
 ## [3.1.11](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.10...dart-3.1.11) (2023-01-21)
 

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.12](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.11...dart-3.1.12) (2023-02-01)
+
+### Bug Fixes
+
+* fix `fromJson` in ParseBase ([#688](https://github.com/parse-community/Parse-SDK-Flutter/issues/688))
+
 ## [3.1.11](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.10...dart-3.1.11) (2023-01-21)
 
 ### Features

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.1.11';
+const String keySdkVersion = '3.1.12';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/objects/parse_base.dart
+++ b/packages/dart/lib/src/objects/parse_base.dart
@@ -139,6 +139,7 @@ abstract class ParseBase {
         _getObjectData()[keyVarAcl] = ParseACL().fromJson(value);
       } else {
         _getObjectData()[key] = parseDecode(value);
+        _unsavedChanges[key] = _getObjectData()[key];
       }
     });
 

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.11
+version: 3.1.12
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
```fromJson``` not work in ```save```

Closes: #688

### Approach
added ```_unsavedChanges``` in fromJson  for fix bug.

### TODOs before merging
- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry
