### PR TITLE
fix: Dio error holds a reference to null values

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.14](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.13...dart-3.1.14) (2023-02-26)
+
+### Bug Fixes
+
+* Dio error object holds a reference to null values ([#774](https://github.com/parse-community/Parse-SDK-Flutter/issues/774))
+
 ## [3.1.13](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.12...dart-3.1.13) (2023-02-15)
 
 ### Bug Fixes
@@ -161,7 +167,7 @@ Bug fixes
 ## 1.0.22
 
 Added dirty children
-Added option of sembast or share_preferences 
+Added option of sembast or share_preferences
 
 ## 1.0.21
 
@@ -183,7 +189,7 @@ Bug fix
 
 ## 1.0.17
 
-LiveQuery fix 
+LiveQuery fix
 Bug fixes
 
 ## 1.0.16

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.1.13';
+const String keySdkVersion = '3.1.14';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -27,11 +27,16 @@ class ParseDioClient extends ParseClient {
         path,
         options: _Options(headers: options?.headers),
       );
+      
       return ParseNetworkResponse(
-          data: dioResponse.data!, statusCode: dioResponse.statusCode!);
+        data: dioResponse.data!,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? _fallbackErrorData,
+        statusCode: error.response?.statusCode ?? ParseError.otherCause,
+      );
     }
   }
 
@@ -51,12 +56,15 @@ class ParseDioClient extends ParseClient {
             headers: options?.headers, responseType: dio.ResponseType.bytes),
       );
       return ParseNetworkByteResponse(
-          bytes: dioResponse.data, statusCode: dioResponse.statusCode!);
+        bytes: dioResponse.data,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       if (error.response != null) {
         return ParseNetworkByteResponse(
-            data: error.response?.data,
-            statusCode: error.response!.statusCode!);
+          data: error.response?.data ?? _fallbackErrorData,
+          statusCode: error.response?.statusCode ?? ParseError.otherCause,
+        );
       } else {
         return _getOtherCaseErrorForParseNetworkResponse(error.error);
       }
@@ -72,11 +80,16 @@ class ParseDioClient extends ParseClient {
         data: data,
         options: _Options(headers: options?.headers),
       );
+
       return ParseNetworkResponse(
-          data: dioResponse.data!, statusCode: dioResponse.statusCode!);
+        data: dioResponse.data!,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? _fallbackErrorData,
+        statusCode: error.response?.statusCode ?? ParseError.otherCause,
+      );
     }
   }
 
@@ -89,11 +102,16 @@ class ParseDioClient extends ParseClient {
         data: data,
         options: _Options(headers: options?.headers),
       );
+
       return ParseNetworkResponse(
-          data: dioResponse.data!, statusCode: dioResponse.statusCode!);
+        data: dioResponse.data!,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? _fallbackErrorData,
+        statusCode: error.response?.statusCode ?? ParseError.otherCause,
+      );
     }
   }
 
@@ -111,13 +129,17 @@ class ParseDioClient extends ParseClient {
         options: _Options(headers: options?.headers),
         onSendProgress: onSendProgress,
       );
+
       return ParseNetworkResponse(
-          data: dioResponse.data!, statusCode: dioResponse.statusCode!);
+        data: dioResponse.data!,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       if (error.response != null) {
         return ParseNetworkResponse(
-            data: error.response?.data,
-            statusCode: error.response!.statusCode!);
+          data: error.response?.data ?? _fallbackErrorData,
+          statusCode: error.response?.statusCode ?? ParseError.otherCause,
+        );
       } else {
         return _getOtherCaseErrorForParseNetworkResponse(error.error);
       }
@@ -138,13 +160,20 @@ class ParseDioClient extends ParseClient {
         path,
         options: _Options(headers: options?.headers),
       );
+
       return ParseNetworkResponse(
-          data: dioResponse.data!, statusCode: dioResponse.statusCode!);
+        data: dioResponse.data!,
+        statusCode: dioResponse.statusCode!,
+      );
     } on dio.DioError catch (error) {
       return ParseNetworkResponse(
-          data: error.response?.data, statusCode: error.response!.statusCode!);
+        data: error.response?.data ?? _fallbackErrorData,
+        statusCode: error.response?.statusCode ?? ParseError.otherCause,
+      );
     }
   }
+
+  String get _fallbackErrorData => '{"$keyError":"NetworkError"}';
 }
 
 /// Creates a custom version of HTTP Client that has Parse Data Preset

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -27,7 +27,7 @@ class ParseDioClient extends ParseClient {
         path,
         options: _Options(headers: options?.headers),
       );
-      
+
       return ParseNetworkResponse(
         data: dioResponse.data!,
         statusCode: dioResponse.statusCode!,

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.13
+version: 3.1.14
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:


### PR DESCRIPTION
When an error occurs, the Dio error object could hold null properties  causing the error (Type 'Null' is not a subtype of type 'Object')

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: [#774](https://github.com/parse-community/Parse-SDK-Flutter/issues/774)

### Approach
Add null aware operator `??`:
``` dart
on dio.DioError catch (error) {
      return ParseNetworkResponse(
        data: error.response?.data ?? _fallbackErrorData,
        statusCode: error.response?.statusCode ?? ParseError.otherCause,
      );
    }
```

### TODOs before merging
All set

- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry
