### PR TITLE
fix: Parse SDK internal database file `parse.db` is accessible for app user on iOS and may be accidentally deleted

### DIFF
--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.1.4](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.3...flutter-3.1.4) (2023-02-28)
+## [3.1.4](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.3...flutter-3.1.4) (2023-03-01)
 
 ### Bug Fixes
 

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* Sembast database file not hidden on ios ([#791](https://github.com/parse-community/Parse-SDK-Flutter/issues/791))
+* Parse SDK internal database file `parse.db` is accessible for app user on iOS and may be accidentally deleted ([#826](https://github.com/parse-community/Parse-SDK-Flutter/pull/826))
 
 ## [3.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.2...flutter-3.1.3) (2022-07-09)
 

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.4](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.3...flutter-3.1.4) (2023-02-28)
+
+### Bug Fixes
+
+* Sembast database file not hidden on ios ([#791](https://github.com/parse-community/Parse-SDK-Flutter/issues/791))
+
 ## [3.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.2...flutter-3.1.3) (2022-07-09)
 
 ### Bug Fixes
@@ -5,7 +11,6 @@
 * old version of `connectivity_plus package` ([#717](https://github.com/parse-community/Parse-SDK-Flutter/issues/717))
 * dependency `package_info_plus` does not work in web ([#714](https://github.com/parse-community/Parse-SDK-Flutter/issues/714))
 * missing plugin exception, no implementation found for method `getAll` ([#712](https://github.com/parse-community/Parse-SDK-Flutter/issues/712))
-
 
 ## [3.1.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/flutter-3.1.1...flutter-3.1.2) (2022-05-30)
 

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -15,12 +15,9 @@ class CoreStoreDirectory {
     return (await path_provider.getApplicationDocumentsDirectory()).path;
   }
 
-  /// Why do we need this migration on iOS? see:
+  /// Migrate SDK internal database file on iOS, see:
   /// https://github.com/parse-community/Parse-SDK-Flutter/issues/791
-  ///
-  /// TODO: remove this migration algorithm after at least two major releases
-  ///
-  /// the release when this migration added is `3.1.4`
+  /// TODO: Remove this migration algorithm in the future. 
   Future<void> _migrateDBFileToLibraryDirectory() async {
     final dbFile = await _getDBFileIfExistsInAppDocDir();
 

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -17,7 +17,7 @@ class CoreStoreDirectory {
 
   /// Migrate SDK internal database file on iOS, see:
   /// https://github.com/parse-community/Parse-SDK-Flutter/issues/791
-  /// TODO: Remove this migration algorithm in the future. 
+  /// TODO: Remove this migration algorithm in the future.
   Future<void> _migrateDBFileToLibraryDirectory() async {
     final dbFile = await _getDBFileIfExistsInAppDocDir();
 

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -1,11 +1,17 @@
-import 'package:path_provider/path_provider.dart';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart' as path_provider;
 
 class CoreStoreDirectory {
   Future<String> getDatabaseDirectory() async {
-    return (await getApplicationDocumentsDirectory()).path;
+    if (Platform.isIOS) {
+      return (await path_provider.getLibraryDirectory()).path;
+    } else {
+      return (await path_provider.getApplicationDocumentsDirectory()).path;
+    }
   }
 
   Future<String?> getTempDirectory() async {
-    return (await getTemporaryDirectory()).path;
+    return (await path_provider.getTemporaryDirectory()).path;
   }
 }

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -61,8 +61,7 @@ class CoreStoreDirectory {
     );
 
     await File(libraryDirectoryDatabaseFilePath).create(recursive: true);
-    await databaseFileToMove.copy(libraryDirectoryDatabaseFilePath);
-    await databaseFileToMove.delete();
+    await databaseFileToMove.rename(libraryDirectoryDatabaseFilePath);
   }
 
   Future<String> getTempDirectory() async {

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -20,7 +20,7 @@ class CoreStoreDirectory {
   ///
   /// TODO: remove this migration algorithm after at least two major releases
   ///
-  /// the release when this migration added is `3.1.14`
+  /// the release when this migration added is `3.1.4`
   Future<void> _migrateDBFileToLibraryDirectory() async {
     final dbFile = await _getDBFileIfExistsInAppDocDir();
 

--- a/packages/flutter/lib/src/storage/core_store_directory_io.dart
+++ b/packages/flutter/lib/src/storage/core_store_directory_io.dart
@@ -1,17 +1,71 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
+import 'package:path/path.dart' as path;
 
 class CoreStoreDirectory {
   Future<String> getDatabaseDirectory() async {
-    if (Platform.isIOS) {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await _migrateDBFileToLibraryDirectory();
+
       return (await path_provider.getLibraryDirectory()).path;
-    } else {
-      return (await path_provider.getApplicationDocumentsDirectory()).path;
+    }
+
+    return (await path_provider.getApplicationDocumentsDirectory()).path;
+  }
+
+  /// Why do we need this migration on iOS? see:
+  /// https://github.com/parse-community/Parse-SDK-Flutter/issues/791
+  ///
+  /// TODO: remove this migration algorithm after at least two major releases
+  ///
+  /// the release when this migration added is `3.1.14`
+  Future<void> _migrateDBFileToLibraryDirectory() async {
+    final dbFile = await _getDBFileIfExistsInAppDocDir();
+
+    if (dbFile != null) {
+      await _moveDatabaseFileToLibraryDirectory(dbFile);
     }
   }
 
-  Future<String?> getTempDirectory() async {
+  Future<File?> _getDBFileIfExistsInAppDocDir() async {
+    final appDocDirPath =
+        (await path_provider.getApplicationDocumentsDirectory()).path;
+
+    final databaseFilePath = path.join(
+      appDocDirPath,
+      'parse',
+      'parse.db',
+    );
+
+    final dbFile = File(databaseFilePath);
+
+    if (await dbFile.exists()) {
+      return dbFile;
+    }
+
+    return null;
+  }
+
+  Future<void> _moveDatabaseFileToLibraryDirectory(
+    File databaseFileToMove,
+  ) async {
+    final libraryDirectoryPath =
+        (await path_provider.getLibraryDirectory()).path;
+
+    final libraryDirectoryDatabaseFilePath = path.join(
+      libraryDirectoryPath,
+      'parse',
+      'parse.db',
+    );
+
+    await File(libraryDirectoryDatabaseFilePath).create(recursive: true);
+    await databaseFileToMove.copy(libraryDirectoryDatabaseFilePath);
+    await databaseFileToMove.delete();
+  }
+
+  Future<String> getTempDirectory() async {
     return (await path_provider.getTemporaryDirectory()).path;
   }
 }

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: Flutter plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.3
+version: 3.1.4
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -71,7 +71,6 @@ void main() {
           isFalse,
           reason: 'the old db file should be deleted from app doc dir',
         );
-
         expect(
           dbDirectory,
           equals(libraryPath),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -158,7 +158,6 @@ void main() {
             equals(0), // 0 if this DateTime [isAtSameMomentAs] [other]
             reason: 'last modified date should not change',
           );
-
           expect(
             dbDirectory,
             equals(applicationDocumentsPath),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -25,6 +25,7 @@ void main() {
       final result = await path_provider.getTemporaryDirectory();
       expect(result.path, kTemporaryPath);
     });
+    
     test('getLibraryDirectory', () async {
       final result = await path_provider.getLibraryDirectory();
       expect(result.path, libraryPath);

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -25,7 +25,7 @@ void main() {
       final result = await path_provider.getTemporaryDirectory();
       expect(result.path, kTemporaryPath);
     });
-    
+
     test('getLibraryDirectory', () async {
       final result = await path_provider.getLibraryDirectory();
       expect(result.path, libraryPath);
@@ -35,14 +35,14 @@ void main() {
       final result = await path_provider.getApplicationDocumentsDirectory();
       expect(result.path, applicationDocumentsPath);
     });
-    
+
     test('defaultTargetPlatform should equals iOS', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
       final platform = defaultTargetPlatform;
       expect(platform, equals(TargetPlatform.iOS));
     });
-    
+
     test('getTempDirectory() should return kTemporaryPath', () async {
       final path = await coreStoreDirectory.getTempDirectory();
       expect(path, kTemporaryPath);
@@ -127,7 +127,7 @@ void main() {
               'dbDirectory should be the new db dir path for iOS (LibraryDir)',
         );
       });
-      
+
       test(
           'on any platform other than iOS, the copy migration algorithm should '
           'not run and the db file should and will remain in '

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -65,20 +65,11 @@ void main() {
           '(applicationDocumentDirectory) to the new dir path (LibraryDirectory)'
           ' and the old db file should be deleted from the old dir path '
           'then return the new dir path (LibraryDirectory)', () async {
-        // arrange
-
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-        // database in the old path
         final oldDBFile = create1MBParseDBFileInAppDocDir();
         final oldDBFileSize = oldDBFile.lengthSync();
-
-        // act
-
         final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
-
-        // assert
-
         expect(
           oldDBFile.existsSync(),
           isFalse,

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -87,7 +87,6 @@ void main() {
         final newDBFile = File(newDBFilePath);
 
         expect(newDBFile.existsSync(), isTrue);
-
         expect(
           newDBFile.lengthSync(),
           equals(oldDBFileSize),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -85,7 +85,6 @@ void main() {
           'parse.db',
         );
         final newDBFile = File(newDBFilePath);
-
         expect(newDBFile.existsSync(), isTrue);
         expect(
           newDBFile.lengthSync(),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -99,17 +99,12 @@ void main() {
           ' and there is db file in the new dir (LibraryDirectory) '
           'the (copy) migration should not work and so the getDatabaseDirectory()'
           'should return the new db dir path (LibraryDirectory)', () async {
-        // arrange
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
         final dbFileInNewPath = create1MBParseDBFileInLibraryPath();
         final dbFileSizeBefore = dbFileInNewPath.lengthSync();
         final dbFileLastModifiedBefore = dbFileInNewPath.lastModifiedSync();
-
-        // act
         final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
-
-        // assert
         expect(dbFileInNewPath.existsSync(), isTrue);
 
         final dbFileSizeAfter = dbFileInNewPath.lengthSync();

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -40,6 +40,7 @@ void main() {
       final platform = defaultTargetPlatform;
       expect(platform, equals(TargetPlatform.iOS));
     });
+    
     test('getTempDirectory() should return kTemporaryPath', () async {
       final path = await coreStoreDirectory.getTempDirectory();
       expect(path, kTemporaryPath);

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -142,10 +142,7 @@ void main() {
         for (final platform in targetPlatforms) {
           debugDefaultTargetPlatformOverride = platform;
 
-          // act
           final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
-
-          // assert
           expect(dbFile.existsSync(), isTrue);
 
           final dbFileSizeAfter = dbFile.lengthSync();

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -127,6 +127,7 @@ void main() {
               'dbDirectory should be the new db dir path for iOS (LibraryDir)',
         );
       });
+      
       test(
           'on any platform other than iOS, the copy migration algorithm should '
           'not run and the db file should and will remain in '

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -34,6 +34,7 @@ void main() {
       final result = await path_provider.getApplicationDocumentsDirectory();
       expect(result.path, applicationDocumentsPath);
     });
+    
     test('defaultTargetPlatform should equals iOS', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -120,7 +120,6 @@ void main() {
           equals(0), // 0 if this DateTime [isAtSameMomentAs] [other]
           reason: 'last modified date should not change',
         );
-
         expect(
           dbDirectory,
           equals(libraryPath),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -147,7 +147,6 @@ void main() {
 
           final dbFileSizeAfter = dbFile.lengthSync();
           final dbFileLastModifiedSyncAfter = dbFile.lastModifiedSync();
-
           expect(
             dbFileSizeBefore,
             equals(dbFileSizeAfter),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -1,0 +1,266 @@
+@TestOn('dart-vm')
+@Timeout.factor(2)
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:path_provider/path_provider.dart' as path_provider;
+import 'package:path/path.dart' as path;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parse_server_sdk_flutter/src/storage/core_store_directory_io.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('Core store directory IO', () {
+    late CoreStoreDirectory coreStoreDirectory;
+    setUp(() {
+      PathProviderPlatform.instance = FakePathProviderPlatform();
+      coreStoreDirectory = CoreStoreDirectory();
+    });
+
+    test('getTemporaryDirectory', () async {
+      final result = await path_provider.getTemporaryDirectory();
+      expect(result.path, kTemporaryPath);
+    });
+    test('getLibraryDirectory', () async {
+      final result = await path_provider.getLibraryDirectory();
+      expect(result.path, libraryPath);
+    });
+
+    test('getApplicationDocumentsDirectory', () async {
+      final result = await path_provider.getApplicationDocumentsDirectory();
+      expect(result.path, applicationDocumentsPath);
+    });
+    test('defaultTargetPlatform should equals iOS', () async {
+      // arrange
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      // act
+      final platform = defaultTargetPlatform;
+
+      // assert
+      expect(platform, equals(TargetPlatform.iOS));
+    });
+    test('getTempDirectory() should return kTemporaryPath', () async {
+      final path = await coreStoreDirectory.getTempDirectory();
+      expect(path, kTemporaryPath);
+    });
+
+    group('getDatabaseDirectory()', () {
+      setUp(() {
+        deleteApplicationDocumentDir();
+        deleteLibraryDir();
+      });
+
+      tearDown(() {
+        deleteApplicationDocumentDir();
+        deleteLibraryDir();
+      });
+
+      test(
+          'on ios, should copy the db file if exists from the old dir path '
+          '(applicationDocumentDirectory) to the new dir path (LibraryDirectory)'
+          ' and the old db file should be deleted from the old dir path '
+          'then return the new dir path (LibraryDirectory)', () async {
+        // arrange
+
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+        // database in the old path
+        final oldDBFile = create1MBParseDBFileInAppDocDir();
+        final oldDBFileSize = oldDBFile.lengthSync();
+
+        // act
+
+        final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
+
+        // assert
+
+        expect(
+          oldDBFile.existsSync(),
+          isFalse,
+          reason: 'the old db file should be deleted from app doc dir',
+        );
+
+        expect(
+          dbDirectory,
+          equals(libraryPath),
+          reason:
+              'dbDirectory should be the new db dir path for iOS (LibraryDir)',
+        );
+
+        final newDBFilePath = path.join(
+          dbDirectory,
+          'parse',
+          'parse.db',
+        );
+        final newDBFile = File(newDBFilePath);
+
+        expect(newDBFile.existsSync(), isTrue);
+
+        expect(
+          newDBFile.lengthSync(),
+          equals(oldDBFileSize),
+          reason: 'the old and the new coped db file should be the same size',
+        );
+      });
+
+      test(
+          'on ios, if there is no db file in the old dir (applicationDocumentDirectory)'
+          ' and there is db file in the new dir (LibraryDirectory) '
+          'the (copy) migration should not work and so the getDatabaseDirectory()'
+          'should return the new db dir path (LibraryDirectory)', () async {
+        // arrange
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+        final dbFileInNewPath = create1MBParseDBFileInLibraryPath();
+        final dbFileSizeBefore = dbFileInNewPath.lengthSync();
+        final dbFileLastModifiedBefore = dbFileInNewPath.lastModifiedSync();
+
+        // act
+        final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
+
+        // assert
+        expect(dbFileInNewPath.existsSync(), isTrue);
+
+        final dbFileSizeAfter = dbFileInNewPath.lengthSync();
+        final dbFileLastModifiedAfter = dbFileInNewPath.lastModifiedSync();
+
+        expect(
+          dbFileSizeBefore,
+          equals(dbFileSizeAfter),
+          reason: 'the db file should be the same',
+        );
+        expect(
+          dbFileLastModifiedBefore.compareTo(dbFileLastModifiedAfter),
+          equals(0), // 0 if this DateTime [isAtSameMomentAs] [other]
+          reason: 'last modified date should not change',
+        );
+
+        expect(
+          dbDirectory,
+          equals(libraryPath),
+          reason:
+              'dbDirectory should be the new db dir path for iOS (LibraryDir)',
+        );
+      });
+      test(
+          'on any platform other than iOS, the copy migration algorithm should '
+          'not run and the db file should and will remain in '
+          '(applicationDocumentDirectory) and getDatabaseDirectory() should '
+          'return (applicationDocumentDirectory) as db directory', () async {
+        final targetPlatforms = TargetPlatform.values.toSet();
+        targetPlatforms.remove(TargetPlatform.iOS);
+
+        final dbFile = create1MBParseDBFileInAppDocDir();
+        final dbFileSizeBefore = dbFile.lengthSync();
+        final dbFileLastModifiedBefore = dbFile.lastModifiedSync();
+
+        for (final platform in targetPlatforms) {
+          debugDefaultTargetPlatformOverride = platform;
+
+          // act
+          final dbDirectory = await coreStoreDirectory.getDatabaseDirectory();
+
+          // assert
+          expect(dbFile.existsSync(), isTrue);
+
+          final dbFileSizeAfter = dbFile.lengthSync();
+          final dbFileLastModifiedSyncAfter = dbFile.lastModifiedSync();
+
+          expect(
+            dbFileSizeBefore,
+            equals(dbFileSizeAfter),
+            reason: 'the db file should be the same',
+          );
+          expect(
+            dbFileLastModifiedBefore.compareTo(dbFileLastModifiedSyncAfter),
+            equals(0), // 0 if this DateTime [isAtSameMomentAs] [other]
+            reason: 'last modified date should not change',
+          );
+
+          expect(
+            dbDirectory,
+            equals(applicationDocumentsPath),
+            reason:
+                'dbDirectory should point to application Documents Directory',
+          );
+        }
+      });
+    });
+  });
+}
+
+File create1MBParseDBFileInAppDocDir() {
+  final databaseFilePath = path.join(
+    applicationDocumentsPath,
+    'parse',
+    'parse.db',
+  );
+
+  return generate1MBFile(databaseFilePath);
+}
+
+File create1MBParseDBFileInLibraryPath() {
+  final databaseFilePath = path.join(
+    libraryPath,
+    'parse',
+    'parse.db',
+  );
+
+  return generate1MBFile(databaseFilePath);
+}
+
+File generate1MBFile(String path) {
+  final dbFile = File(path);
+  dbFile.createSync(recursive: true, exclusive: false);
+
+  const fileSize = 1024 * 1024; // 1 MB
+  final random = Random();
+  final data = List.generate(fileSize, (_) => random.nextInt(256));
+
+  dbFile.writeAsBytesSync(data, flush: true, mode: FileMode.write);
+  return dbFile;
+}
+
+void deleteApplicationDocumentDir() {
+  deleteDirectory(applicationDocumentsPath);
+}
+
+void deleteLibraryDir() {
+  deleteDirectory(libraryPath);
+}
+
+void deleteDirectory(String path) {
+  final dir = Directory(path);
+  if (dir.existsSync()) {
+    dir.deleteSync(recursive: true);
+  }
+}
+
+const String kTemporaryPath = "temporaryPath";
+final String libraryPath = path.join(path.current, 'library');
+final String applicationDocumentsPath =
+    path.join(path.current, 'applicationDocument');
+
+class FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  @override
+  Future<String?> getTemporaryPath() async {
+    return kTemporaryPath;
+  }
+
+  @override
+  Future<String?> getLibraryPath() async {
+    return libraryPath;
+  }
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return applicationDocumentsPath;
+  }
+}

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -109,7 +109,6 @@ void main() {
 
         final dbFileSizeAfter = dbFileInNewPath.lengthSync();
         final dbFileLastModifiedAfter = dbFileInNewPath.lastModifiedSync();
-
         expect(
           dbFileSizeBefore,
           equals(dbFileSizeAfter),

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -35,13 +35,9 @@ void main() {
       expect(result.path, applicationDocumentsPath);
     });
     test('defaultTargetPlatform should equals iOS', () async {
-      // arrange
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-      // act
       final platform = defaultTargetPlatform;
-
-      // assert
       expect(platform, equals(TargetPlatform.iOS));
     });
     test('getTempDirectory() should return kTemporaryPath', () async {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: [#791](https://github.com/parse-community/Parse-SDK-Flutter/issues/791)

### Approach
Using LibraryDirectory as a path for the database.

### TODOs before merging
 This is a breaking change for **_ios_** platform because the SDK now will look for the "parse.db" in the `LibraryDirectory` rather than the `ApplicationDocumentsDirectory`.

We can support the old directory path by doing something like:
``` dart
  Future<String> getDatabaseDirectory() async {
    if (Platform.isIOS) {
      if(await _isDatabaseFileExistsInOldPath()){
        return (await path_provider.getApplicationDocumentsDirectory()).path;
      }
      return (await path_provider.getLibraryDirectory()).path;
    } else {
      return (await path_provider.getApplicationDocumentsDirectory()).path;
    }
  }

  Future<bool> _isDatabaseFileExistsInOldPath() async {
    final oldIosDatabaseDirPath =
        (await path_provider.getApplicationDocumentsDirectory()).path;
    final oldDatabaseFile =
        path.join('$oldIosDatabaseDirPath/parse', 'parse.db');

    if (await File(oldDatabaseFile).exists()) {
      return true;
    }
    return false;
  }
```

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry
