### PR TITLE
fix: Updating and deleting a ParseObject sends requests even if object ID is null

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.15](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.14...dart-3.1.15) (2023-02-28)
+
+### Bug Fixes
+
+* Updating and deleting a ParseObject sends requests even if object ID is null ([#829](https://github.com/parse-community/Parse-SDK-Flutter/pull/829))
+
 ## [3.1.14](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-3.1.13...dart-3.1.14) (2023-02-26)
 
 ### Bug Fixes

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '3.1.14';
+const String keySdkVersion = '3.1.15';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -86,6 +86,11 @@ class ParseObject extends ParseBase implements ParseCloneable {
   }
 
   Future<ParseResponse> update() async {
+    assert(
+      objectId != null && (objectId?.isNotEmpty ?? false),
+      "Can't update a parse object while the objectId property is null or empty",
+    );
+
     try {
       final Uri url = getSanitisedUri(_client, '$_path/$objectId');
       final String body = json.encode(toJson(forApiRQ: true));
@@ -443,8 +448,23 @@ class ParseObject extends ParseBase implements ParseCloneable {
   }
 
   /// Deletes the current object locally and online
-  Future<ParseResponse> delete<T extends ParseObject>(
-      {String? id, String? path}) async {
+  Future<ParseResponse> delete<T extends ParseObject>({
+    String? id,
+    String? path,
+  }) async {
+    assert(() {
+      final objId = objectId;
+      final isNotValidObjectId = objId == null || objId.isEmpty;
+      final isNotValidIdArg = id == null || id.isEmpty;
+
+      if (isNotValidObjectId && isNotValidIdArg) {
+        throw "Can't delete a parse object while the objectId property "
+            "and id argument is null or empty";
+      }
+
+      return true;
+    }());
+
     try {
       path ??= _path;
       id ??= objectId;

--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -458,8 +458,10 @@ class ParseObject extends ParseBase implements ParseCloneable {
       final isNotValidIdArg = id == null || id.isEmpty;
 
       if (isNotValidObjectId && isNotValidIdArg) {
-        throw "Can't delete a parse object while the objectId property "
-            "and id argument is null or empty";
+        throw Exception(
+          "Can't delete a parse object while the objectId property "
+          "and id argument is null or empty",
+        );
       }
 
       return true;

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 3.1.14
+version: 3.1.15
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description

Closes: [#828](https://github.com/parse-community/Parse-SDK-Flutter/issues/828)

### Approach
Use `assert()` to make sure that the `objectId` is valid and can be used

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry
