### PR TITLE
fix: Attempt to save `ParseObject` even if its nested `ParseObject` failed to save

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.0.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-21)
+## [4.0.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-23)
 
 ### Bug Fixes
 

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-21)
+
+### Bug Fixes
+
+* The SDK will try to save a ParseObject even if its child ParseObject not saved ([#859](https://github.com/parse-community/Parse-SDK-Flutter/pull/859))
+
 ## [4.0.1](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-20)
 
 ### Bug Fixes

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.0.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-23)
+## [4.0.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.1...dart-4.0.2) (2023-03-23)
 
 ### Bug Fixes
 

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* The SDK will try to save a ParseObject even if its child ParseObject not saved ([#859](https://github.com/parse-community/Parse-SDK-Flutter/pull/859))
+* Attempt to save `ParseObject` even if its nested `ParseObject` failed to save ([#859](https://github.com/parse-community/Parse-SDK-Flutter/pull/859))
 
 ## [4.0.1](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.0...dart-4.0.1) (2023-03-20)
 

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '4.0.1';
+const String keySdkVersion = '4.0.2';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: Dart plugin for Parse Server, (https://parseplatform.org), (https://back4app.com)
-version: 4.0.1
+version: 4.0.2
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/dart/test/src/objects/parse_object/parse_object_save_test.dart
+++ b/packages/dart/test/src/objects/parse_object/parse_object_save_test.dart
@@ -481,7 +481,6 @@ void main() {
 
         verifyNoMoreInteractions(client);
       },
-      skip: 'see #853 and #854',
     );
   });
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #854

### Approach
<!-- Add a description of the approach in this PR. -->
Consider the `totalResponse` from the batch as unsuccessful
``` dart 

// if any request in a batch requests group fails,
// then the overall response will be considered unsuccessful.
totalResponse.success = false;

```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

Merge #858 first, then I will add a change log entry with that PR, so we publish two fixes in one version.(4.0.1)


- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry
