### PR TITLE
ci: Add Dart / Flutter version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,39 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.18.0, 2.19.0]
+        include:
+          - name: Ubuntu
+            os: ubuntu-latest
+            sdk: 2.19.6
+          - name: MacOS
+            os: macos-latest
+            sdk: 2.19.6
+          - name: Windows
+            os: windows-latest
+            sdk: 2.19.6
+          - name: Dart 2.18
+            os: ubuntu-latest
+            sdk: 2.18.0
+          - name: Dart 2.17
+            os: ubuntu-latest
+            sdk: 2.17.0
+          - name: Dart 2.16
+            os: ubuntu-latest
+            sdk: 2.16.0
+          - name: Dart 2.15
+            os: ubuntu-latest
+            sdk: 2.15.0
+          - name: Dart 2.14
+            os: ubuntu-latest
+            sdk: 2.14.0
+          - name: Dart 2.13
+            os: ubuntu-latest
+            sdk: 2.13.0
+          - name: Dart 2.12
+            os: ubuntu-latest
+            sdk: 2.12.0
       fail-fast: false
-    name: Test dart (${{ matrix.os }}, Dart ${{ matrix.sdk }})
+    name: ${{ matrix.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         run: (cd packages/dart && dart run build_runner build --delete-conflicting-outputs)
       - name: Analyze code
         run: dart analyze packages/dart
+      - name: Publish dry run
+        run: cd packages/dart && dart pub publish --dry-run
       - name: Run tests
         run: (cd packages/dart && dart test --coverage=coverage)
       - name: Convert code coverage
@@ -178,6 +180,8 @@ jobs:
           cmd /c "cd packages\flutter && flutter pub get"
       - name: Analyze code
         run: flutter analyze packages/flutter --no-fatal-infos
+      - name: Publish dry run
+        run: cd packages/flutter && dart pub publish --dry-run
       - name: Run tests
         run: (cd packages/flutter && flutter test --coverage)
       - name: Convert code coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Dart SDK may contain breaking changes in minor version releases, i.e. it doesn't
+          # follow semver, see 
+          - name: Flutter 3.10, Ubuntu
+            os: ubuntu-latest
+            sdk: 3.10.x
+          - name: Flutter 3.10, macOS
+            os: macos-latest
+            sdk: 3.10.x
+          - name: Flutter 3.10, Windows
+            os: windows-latest
+            sdk: 3.10.x
+          # Only the latest Flutter SDK version (above) is tested with all architectures. Previous
+          # Flutter SDK versions (below) are only tested with Ubuntu to reduce CI resource usage.
+          - name: Flutter 3.7
+            os: ubuntu-latest
+            sdk: 3.7.x
+          - name: Flutter 3.3
+            os: ubuntu-latest
+            sdk: 3.3.x
+          - name: Flutter 3.0
+            os: ubuntu-latest
+            sdk: 3.0.x
       fail-fast: false
     name: Test flutter (${{ matrix.os }})
     steps:
@@ -102,6 +124,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ matrix.sdk }}
           cache: true
       - name: Install dependencies on Ubuntu and MacOS
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,19 @@ on:
     branches:
       - "**"
 jobs:
+  check-lint-dart:
+    name: Lint (Dart)
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup dart
+        uses: dart-lang/setup-dart@v1
+      - name: Lint
+        run: dart format --output=none --set-exit-if-changed packages/dart
   check-lint-flutter:
-    name: Lint (flutter)
+    name: Lint (Flutter)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -24,8 +35,8 @@ jobs:
           cache: true
       - name: Lint
         run: dart format --output=none --set-exit-if-changed packages/flutter
-  check-lint-dart:
-    name: Lint (dart)
+  check-code-analysis-dart:
+    name: Code analysis (Dart)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -33,10 +44,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup dart
         uses: dart-lang/setup-dart@v1
-      - name: Lint
-        run: dart format --output=none --set-exit-if-changed packages/dart
+      - name: Install dependencies
+        run: dart pub get --directory packages/dart
+      - name: Analyze code
+        run: dart analyze packages/dart
   check-code-analysis-flutter:
-    name: Code analysis (flutter)
+    name: Code analysis (Flutter)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -52,21 +65,8 @@ jobs:
           (cd packages/flutter && flutter pub get)
       - name: Analyze code
         run: flutter analyze packages/flutter --no-fatal-infos
-  check-code-analysis-dart:
-    name: Code analysis (dart)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup dart
-        uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        run: dart pub get --directory packages/dart
-      - name: Analyze code
-        run: dart analyze packages/dart
   check-publish-dry-run-dart:
-    name: Publish dry-run (dart)
+    name: Publish dry-run (Dart)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
       - name: publish dry run
         run: cd packages/dart && dart pub publish --dry-run
   check-publish-dry-run-flutter:
-    name: Publish dry-run (flutter)
+    name: Publish dry-run (Flutter)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache: true
       - name: Lint
-        run: flutter format --output=none --set-exit-if-changed packages/flutter
+        run: dart format --output=none --set-exit-if-changed packages/flutter
   check-lint-dart:
     name: Lint (dart)
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Analyze code
         run: dart analyze packages/dart
   check-publish-dry-run-dart:
-    name: publish dry-run (dart)
+    name: Publish dry-run (dart)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
       - name: publish dry run
         run: cd packages/dart && dart pub publish --dry-run
   check-publish-dry-run-flutter:
-    name: publish dry-run (flutter)
+    name: Publish dry-run (flutter)
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -134,18 +134,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Dart Ubuntu
-            os: ubuntu-latest
-            sdk: 2.19.6
-          - name: Dart macOS
-            os: macos-latest
-            sdk: 2.19.6
-          - name: Dart Windows
-            os: windows-latest
-            sdk: 2.19.6
-          - name: Dart 3.0
+          - name: Dart 3.0, Ubuntu
             os: ubuntu-latest
             sdk: 3.0.0
+          - name: Dart 3.0, macOS
+            os: macos-latest
+            sdk: 3.0.0
+          - name: Dart 3.0, Windows
+            os: windows-latest
+            sdk: 3.0.0
+          - name: Dart 2.19
+            os: ubuntu-latest
+            sdk: 2.19.6
           - name: Dart 2.18
             os: ubuntu-latest
             sdk: 2.18.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,54 +11,6 @@ on:
     branches:
       - "**"
 jobs:
-  check-lint-dart:
-    name: Lint (Dart)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup dart
-        uses: dart-lang/setup-dart@v1
-      - name: Lint
-        run: dart format --output=none --set-exit-if-changed packages/dart
-  check-lint-flutter:
-    name: Lint (Flutter)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup flutter
-        uses: subosito/flutter-action@v2
-        with:
-          cache: true
-      - name: Lint
-        run: dart format --output=none --set-exit-if-changed packages/flutter
-  check-publish-dry-run-dart:
-    name: Publish dry-run (Dart)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup dart
-        uses: dart-lang/setup-dart@v1
-      - name: publish dry run
-        run: cd packages/dart && dart pub publish --dry-run
-  check-publish-dry-run-flutter:
-    name: Publish dry-run (Flutter)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup flutter
-        uses: subosito/flutter-action@v2
-        with:
-          cache: true
-      - name: publish dry run
-        run: cd packages/flutter && dart pub publish --dry-run
   check-dart:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -116,6 +68,8 @@ jobs:
         run: (cd packages/dart && dart run build_runner build --delete-conflicting-outputs)
       - name: Analyze code
         run: dart analyze packages/dart
+      - name: Lint
+        run: dart format --output=none --set-exit-if-changed packages/dart
       - name: Publish dry run
         run: cd packages/dart && dart pub publish --dry-run
       - name: Run tests
@@ -180,6 +134,8 @@ jobs:
           cmd /c "cd packages\flutter && flutter pub get"
       - name: Analyze code
         run: flutter analyze packages/flutter --no-fatal-infos
+      - name: Lint
+        run: dart format --output=none --set-exit-if-changed packages/flutter
       - name: Publish dry run
         run: cd packages/flutter && dart pub publish --dry-run
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [2.18.0, 2.19.0]
       fail-fast: false
-    name: Test dart (${{ matrix.os }})
+    name: Test dart (${{ matrix.os }}, Dart ${{ matrix.sdk }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Setup dart
         uses: dart-lang/setup-dart@v1.5.0
         with:
-          sdk: 2.19.0
+          sdk: ^2.19.0
       - name: Install dependencies
         run: dart pub get --directory packages/dart
       - name: Run build_runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@v1.5.0
+        with:
+          sdk: 2.19.0
       - name: Install dependencies
         run: dart pub get --directory packages/dart
       - name: Run build_runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,36 +35,6 @@ jobs:
           cache: true
       - name: Lint
         run: dart format --output=none --set-exit-if-changed packages/flutter
-  check-code-analysis-dart:
-    name: Code analysis (Dart)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup dart
-        uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        run: dart pub get --directory packages/dart
-      - name: Analyze code
-        run: dart analyze packages/dart
-  check-code-analysis-flutter:
-    name: Code analysis (Flutter)
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup flutter
-        uses: subosito/flutter-action@v2
-        with:
-          cache: true
-      - name: Install dependencies
-        run: |
-          (cd packages/dart && flutter pub get)
-          (cd packages/flutter && flutter pub get)
-      - name: Analyze code
-        run: flutter analyze packages/flutter --no-fatal-infos
   check-publish-dry-run-dart:
     name: Publish dry-run (Dart)
     timeout-minutes: 5
@@ -89,66 +59,6 @@ jobs:
           cache: true
       - name: publish dry run
         run: cd packages/flutter && dart pub publish --dry-run
-  check-flutter:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          # Dart SDK may contain breaking changes in minor version releases, i.e. it doesn't
-          # follow semver, see 
-          - name: Flutter 3.10, Ubuntu
-            os: ubuntu-latest
-            sdk: 3.10.x
-          - name: Flutter 3.10, macOS
-            os: macos-latest
-            sdk: 3.10.x
-          - name: Flutter 3.10, Windows
-            os: windows-latest
-            sdk: 3.10.x
-          # Only the latest Flutter SDK version (above) is tested with all architectures. Previous
-          # Flutter SDK versions (below) are only tested with Ubuntu to reduce CI resource usage.
-          - name: Flutter 3.7
-            os: ubuntu-latest
-            sdk: 3.7.x
-          - name: Flutter 3.3
-            os: ubuntu-latest
-            sdk: 3.3.x
-      fail-fast: false
-    name: Test ${{ matrix.name }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ matrix.sdk }}
-          cache: true
-      - name: Install dependencies on Ubuntu and MacOS
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: |
-          (cd packages/dart && flutter pub get)
-          (cd packages/flutter && flutter pub get)
-      - name: Install dependencies on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          cmd /c "cd packages\dart && flutter pub get"
-          cmd /c "cd packages\flutter && flutter pub get"
-      - name: Run tests
-        run: (cd packages/flutter && flutter test --coverage)
-      - name: Convert code coverage
-        # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
-        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-        working-directory: packages/flutter
-        run: |
-          escapedPath="$(echo `pwd` | sed 's/\//\\\//g')"
-          sed "s/^SF:lib/SF:$escapedPath\/lib/g" coverage/lcov.info > coverage/lcov-full.info
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v2
-        # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
-        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-        with:
-          files: packages/flutter/coverage/lcov-full.info
-          fail_ci_if_error: true
   check-dart:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -204,6 +114,8 @@ jobs:
         run: dart pub get --directory packages/dart
       - name: Run build_runner
         run: (cd packages/dart && dart run build_runner build --delete-conflicting-outputs)
+      - name: Analyze code
+        run: dart analyze packages/dart
       - name: Run tests
         run: (cd packages/dart && dart test --coverage=coverage)
       - name: Convert code coverage
@@ -219,6 +131,68 @@ jobs:
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         with:
           files: packages/dart/coverage/lcov.info
+          fail_ci_if_error: true
+  check-flutter:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Dart SDK may contain breaking changes in minor version releases, i.e. it doesn't
+          # follow semver, see 
+          - name: Flutter 3.10, Ubuntu
+            os: ubuntu-latest
+            sdk: 3.10.x
+          - name: Flutter 3.10, macOS
+            os: macos-latest
+            sdk: 3.10.x
+          - name: Flutter 3.10, Windows
+            os: windows-latest
+            sdk: 3.10.x
+          # Only the latest Flutter SDK version (above) is tested with all architectures. Previous
+          # Flutter SDK versions (below) are only tested with Ubuntu to reduce CI resource usage.
+          - name: Flutter 3.7
+            os: ubuntu-latest
+            sdk: 3.7.x
+          - name: Flutter 3.3
+            os: ubuntu-latest
+            sdk: 3.3.x
+      fail-fast: false
+    name: Test ${{ matrix.name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.sdk }}
+          cache: true
+      - name: Install dependencies on Ubuntu and MacOS
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: |
+          (cd packages/dart && flutter pub get)
+          (cd packages/flutter && flutter pub get)
+      - name: Install dependencies on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          cmd /c "cd packages\dart && flutter pub get"
+          cmd /c "cd packages\flutter && flutter pub get"
+      - name: Analyze code
+        run: flutter analyze packages/flutter --no-fatal-infos
+      - name: Run tests
+        run: (cd packages/flutter && flutter test --coverage)
+      - name: Convert code coverage
+        # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        working-directory: packages/flutter
+        run: |
+          escapedPath="$(echo `pwd` | sed 's/\//\\\//g')"
+          sed "s/^SF:lib/SF:$escapedPath\/lib/g" coverage/lcov.info > coverage/lcov-full.info
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v2
+        # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        with:
+          files: packages/flutter/coverage/lcov-full.info
           fail_ci_if_error: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
             os: ubuntu-latest
             sdk: 3.0.x
       fail-fast: false
-    name: Test flutter (${{ matrix.os }})
+    name: Test ${{ matrix.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,6 @@ jobs:
           - name: Flutter 3.3
             os: ubuntu-latest
             sdk: 3.3.x
-          - name: Flutter 3.0
-            os: ubuntu-latest
-            sdk: 3.0.x
       fail-fast: false
     name: Test ${{ matrix.name }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,36 +134,39 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ubuntu
+          - name: Dart Ubuntu
             os: ubuntu-latest
             sdk: 2.19.6
-          - name: MacOS
+          - name: Dart macOS
             os: macos-latest
             sdk: 2.19.6
-          - name: Windows
+          - name: Dart Windows
             os: windows-latest
             sdk: 2.19.6
+          - name: Dart 3.0
+            os: ubuntu-latest
+            sdk: 3.0.0
           - name: Dart 2.18
             os: ubuntu-latest
-            sdk: 2.18.0
+            sdk: 2.18.7
           - name: Dart 2.17
             os: ubuntu-latest
-            sdk: 2.17.0
+            sdk: 2.17.7
           - name: Dart 2.16
             os: ubuntu-latest
-            sdk: 2.16.0
+            sdk: 2.16.2
           - name: Dart 2.15
             os: ubuntu-latest
-            sdk: 2.15.0
+            sdk: 2.15.1
           - name: Dart 2.14
             os: ubuntu-latest
-            sdk: 2.14.0
+            sdk: 2.14.4
           - name: Dart 2.13
             os: ubuntu-latest
-            sdk: 2.13.0
+            sdk: 2.13.4
           - name: Dart 2.12
             os: ubuntu-latest
-            sdk: 2.12.0
+            sdk: 2.12.4
       fail-fast: false
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        sdk: [2.18.0, 2.19.0]
       fail-fast: false
     name: Test dart (${{ matrix.os }})
     steps:
@@ -142,7 +143,7 @@ jobs:
       - name: Setup dart
         uses: dart-lang/setup-dart@v1.5.0
         with:
-          sdk: 2.19
+          sdk: ${{ matrix.sdk }}
       - name: Install dependencies
         run: dart pub get --directory packages/dart
       - name: Run build_runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Setup dart
         uses: dart-lang/setup-dart@v1.5.0
         with:
-          sdk: ^2.19.0
+          sdk: 2.19
       - name: Install dependencies
         run: dart pub get --directory packages/dart
       - name: Run build_runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
     strategy:
       matrix:
         include:
+          # Dart SDK may contain breaking changes in minor version releases, i.e. it doesn't
+          # follow semver, see 
           - name: Dart 3.0, Ubuntu
             os: ubuntu-latest
             sdk: 3.0.0
@@ -143,6 +145,8 @@ jobs:
           - name: Dart 3.0, Windows
             os: windows-latest
             sdk: 3.0.0
+          # Only the latest Dart SDK version (above) is tested with all architectures. Previous
+          # Dart SDK versions (below) are only tested with Ubuntu to reduce CI resource usage.
           - name: Dart 2.19
             os: ubuntu-latest
             sdk: 2.19.6
@@ -168,7 +172,7 @@ jobs:
             os: ubuntu-latest
             sdk: 2.12.4
       fail-fast: false
-    name: ${{ matrix.name }}
+    name: Test ${{ matrix.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -6,6 +6,7 @@ This library gives you access to the powerful Parse Server backend from your Dar
 
 ---
 
+- [Compatibility](#compatibility)
 - [Getting Started](#getting-started)
     - [Early Web support](#early-web-support)
 - [Objects](#objects)
@@ -34,6 +35,17 @@ This library gives you access to the powerful Parse Server backend from your Dar
 - [Other Features](#other-features)
 
 ---
+
+## Compatibility
+
+The Parse Dart SDK is continuously tested with the most recent release of the Dart framework to ensure compatibility. To give developers time to upgrade their app to the newest Dart framework, previous Dart framework releases are supported for at least 1 year after their [release date](https://dart.dev/get-dart/archive).
+
+| Version   | Latest Version | End of Support | Compatible                                   |
+|-----------|----------------|----------------|----------------------------------------------|
+| Dart 3.0  | 3.0.0          | May 2024       | ✅ Yes                                        |
+| Dart 2.19 | 2.19.6         | Mar 2024       | ✅ Yes                                        |
+| Dart 2.18 | 2.18.7         | Jan 2024       | ✅ Yes                                        |
+| Dart 2.17 | 2.17.7         | Aug 2023       | ❌ No (Parse Dart SDK requires Dart >=2.18.0) |
 
 ## Getting Started
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -6,8 +6,10 @@ This library gives you access to the powerful Parse Server backend from your Flu
 
 ---
 
+- [Compatibility](#compatibility)
 - [Getting Started](#getting-started)
     - [Web support](#web-support)
+    - [Desktop Support (macOS)](#desktop-support-macos)
     - [Network client](#network-client)
 - [Objects](#objects)
 - [Custom Objects](#custom-objects)
@@ -36,6 +38,17 @@ This library gives you access to the powerful Parse Server backend from your Flu
 - [Other Features](#other-features)
 
 ---
+
+## Compatibility
+
+The Parse Flutter SDK is continuously tested with the most recent release of the Flutter framework to ensure compatibility. To give developers time to upgrade their app to the newest Flutter framework, previous Flutter framework releases are supported for at least 1 year after their [release date](https://docs.flutter.dev/release/archive?tab=linux).
+
+| Version      | End of Support | Compatible                                   |
+|--------------|----------------|----------------------------------------------|
+| Flutter 3.10 | May 2024       | ✅ Yes                                        |
+| Flutter 3.7  | Apr 2024       | ✅ Yes                                        |
+| Flutter 3.3  | Jan 2024       | ✅ Yes                                        |
+| Flutter 3.0  | Jul 2023       | ❌ No (Parse Dart SDK requires Dart >=2.18.0) |
 
 ## Getting Started
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -45,9 +45,9 @@ The Parse Flutter SDK is continuously tested with the most recent release of the
 
 | Version      | End of Support | Compatible                                   |
 |--------------|----------------|----------------------------------------------|
-| Flutter 3.10 | May 2024       | ✅ Yes                                        |
+| Flutter 3.10 | May 2024       | ❌ No                                         |
 | Flutter 3.7  | Apr 2024       | ✅ Yes                                        |
-| Flutter 3.3  | Jan 2024       | ✅ Yes                                        |
+| Flutter 3.3  | Jan 2024       | ❌ No                                         |
 | Flutter 3.0  | Jul 2023       | ❌ No (Parse Dart SDK requires Dart >=2.18.0) |
 
 ## Getting Started

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -41,7 +41,7 @@ This library gives you access to the powerful Parse Server backend from your Flu
 
 ## Compatibility
 
-The Parse Flutter SDK is continuously tested with the most recent release of the Flutter framework to ensure compatibility. To give developers time to upgrade their app to the newest Flutter framework, previous Flutter framework releases are supported for at least 1 year after their [release date](https://docs.flutter.dev/release/archive?tab=linux).
+The Parse Flutter SDK is continuously tested with the most recent release of the Flutter framework to ensure compatibility. To give developers time to upgrade their app to the newest Flutter framework, previous Flutter framework releases are supported for at least 1 year after their [release date](https://docs.flutter.dev/release/archive?tab=linux). The Parse Flutter SDK depends on the Parse Dart SDK which may require a higher Dart framework version than the Flutter framework version, in which case the Flutter framework version cannot be supported even though its release date may have been less than a year ago.
 
 | Version      | End of Support | Compatible                                   |
 |--------------|----------------|----------------------------------------------|


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description

CI is only testing against one (presumably the latest) dart framework version.

Closes: #873 

### Approach

- Add Dart SDK version matrix for testing of all currently officially supported Dart SDK versions.
- Add support policy by adding a compatibility table to the README of each package.
