### PR TITLE
test: Remove optional `exclusive` parameter from core store test

### DIFF
--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -48,7 +48,7 @@ The Parse Flutter SDK is continuously tested with the most recent release of the
 | Flutter 3.10 | May 2024       | ❌ No                                         |
 | Flutter 3.7  | Apr 2024       | ✅ Yes                                        |
 | Flutter 3.3  | Jan 2024       | ✅ Yes                                         |
-| Flutter 3.0  | Jul 2023       | ❌ No (Parse Dart SDK requires Dart >=2.18.0) |
+| Flutter 3.0  | Jul 2023       | ❌ No (Parse Flutter SDK requires Flutter >=3.3.0) |
 
 ## Getting Started
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -47,7 +47,7 @@ The Parse Flutter SDK is continuously tested with the most recent release of the
 |--------------|----------------|----------------------------------------------|
 | Flutter 3.10 | May 2024       | ❌ No                                         |
 | Flutter 3.7  | Apr 2024       | ✅ Yes                                        |
-| Flutter 3.3  | Jan 2024       | ❌ No                                         |
+| Flutter 3.3  | Jan 2024       | ✅ Yes                                         |
 | Flutter 3.0  | Jul 2023       | ❌ No (Parse Dart SDK requires Dart >=2.18.0) |
 
 ## Getting Started

--- a/packages/flutter/test/src/storage/core_store_directory_io_test.dart
+++ b/packages/flutter/test/src/storage/core_store_directory_io_test.dart
@@ -192,7 +192,7 @@ File create1MBParseDBFileInLibraryPath() {
 
 File generate1MBFile(String path) {
   final dbFile = File(path);
-  dbFile.createSync(recursive: true, exclusive: false);
+  dbFile.createSync(recursive: true);
 
   const fileSize = 1024 * 1024; // 1 MB
   final random = Random();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #875

### Approach
<!-- Add a description of the approach in this PR. -->
Remove the optional parameter because it is not supported on Flutter versions >=3.3.0.
This change will not impact the tests, as the default value for this parameter is false. See the [docs](https://api.dart.dev/stable/3.0.0/dart-io/File/createSync.html)

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
