### PR TITLE
ci: Upgrade publish action

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Publish dart package
         if: ${{ startsWith(github.ref_name, 'dart') }}
-        uses: k-paxian/dart-package-publisher@v1.4
+        uses: k-paxian/dart-package-publisher@v1.5.1
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
           refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
           dryRunOnly: false
       - name: Publish flutter package
         if: ${{ startsWith(github.ref_name, 'flutter') }}
-        uses: k-paxian/dart-package-publisher@v1.4
+        uses: k-paxian/dart-package-publisher@v1.5.1
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
           refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: Publish dart package
         if: github.event.inputs.package == 'dart'
-        uses: k-paxian/dart-package-publisher@v1.4
+        uses: k-paxian/dart-package-publisher@v1.5.1
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
           refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
           dryRunOnly: false
       - name: Publish flutter package
         if: github.event.inputs.package == 'flutter'
-        uses: k-paxian/dart-package-publisher@v1.4
+        uses: k-paxian/dart-package-publisher@v1.5.1
         with:
           accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
           refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Publishing to pub.dev fails due to missing credentials of the Google Account to publish. Added Google domain verification for publisher, but workflow still fails.

### Approach

Trying to upgrade publish action k-paxian/dart-package-publisher to latest version to see if that fixes the issue.

