### PR TITLE
feat: Downgrade collection dependency to `^1.16.0` for compatibility with Flutter >=3.3

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.1](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-5.0.0...dart-5.0.1) (2023-05-14)
+
+### Bug Fixes
+* feat: Downgrade collection dependency to ^1.16.0 for compatibility with Flutter >=3.3 ([#880](https://github.com/parse-community/Parse-SDK-Flutter/pull/880))
+  
 ## [5.0.0](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-4.0.2...dart-5.0.0) (2023-05-14)
 
 ### BREAKING CHANGES

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '5.0.1';
+const String keySdkVersion = '5.1.0';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '5.0.0';
+const String keySdkVersion = '5.0.1';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: The Dart SDK for Parse Platform (https://parseplatform.org)
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   mime_type: ^1.0.0
   timezone: ^0.9.1
   universal_io: ^2.2.0
-  collection: ^1.17.1
+  collection: ^1.16.0
 
 dev_dependencies:
   lints: ^2.0.1

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: The Dart SDK for Parse Platform (https://parseplatform.org)
-version: 5.0.1
+version: 5.1.0
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  parse_server_sdk: ^5.0.0
+  parse_server_sdk: ^4.0.0
   # Uncomment for local testing
   #parse_server_sdk:
   #   path: ../dart

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   parse_server_sdk: ^5.0.0
   # Uncomment for local testing
+  
   #parse_server_sdk:
   #   path: ../dart
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  parse_server_sdk: ^4.0.0
+  parse_server_sdk: ^5.0.0
   # Uncomment for local testing
   #parse_server_sdk:
   #   path: ../dart

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
 
   parse_server_sdk: ^5.0.0
   # Uncomment for local testing
-  
   #parse_server_sdk:
   #   path: ../dart
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description

The collection dependency ^1.17.1 makes the Parse Dart SDK incompatible with the `flutter_test` dependency of Flutter <3.10.0. To continue support Flutter >= 3.3, the collection dependency needs to be downgraded.

### Approach

Downgrade collection dependency to ^1.16.0.

### TODO

- [ ] Add cangelog entry
