### PR TITLE
ci: Use `dart pub publish` command for release workflows

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,29 +1,27 @@
 name: release-automated
+
 on:
-  release:
-    types: [ published ]
+  push:
+    tags:
+      - "dart-[0-9]+.[0-9]+.[0-9]+*"
+      - "flutter-[0-9]+.[0-9]+.[0-9]+*"
 jobs:
-  release:
+  release-flutter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Publish dart package
+        uses: actions/checkout@v3.5.2
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1.5.0
+      - name: Publish Dart package
         if: ${{ startsWith(github.ref_name, 'dart') }}
-        uses: k-paxian/dart-package-publisher@v1.5.1
-        with:
-          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-          relativePath: packages/dart
-          format: true
-          dryRunOnly: false
-      - name: Publish flutter package
+        run: |
+          cd packages/dart
+          dart pub get
+          dart pub publish --force
+      - name: Publish Flutter package
         if: ${{ startsWith(github.ref_name, 'flutter') }}
-        uses: k-paxian/dart-package-publisher@v1.5.1
-        with:
-          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-          relativePath: packages/flutter
-          flutter: true
-          format: true
-          dryRunOnly: false
+        run: |
+          cd packages/flutter
+          dart pub get
+          dart pub publish --force

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -8,20 +8,29 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+     dir: ${{ startsWith(github.ref_name, 'flutter') and packages/flutter or packages/dart }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v3
+        
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1.5.0
-      - name: Publish Dart package
-        if: ${{ startsWith(github.ref_name, 'dart') }}
-        run: |
-          cd packages/dart
-          dart pub get
-          dart pub publish --force
-      - name: Publish Flutter package
-        if: ${{ startsWith(github.ref_name, 'flutter') }}
-        run: |
-          cd packages/flutter
-          dart pub get
-          dart pub publish --force
+        uses: dart-lang/setup-dart@v1
+
+      - name: Resolve packages
+        run: dart pub get --directory ${{ env.dir }}
+
+      - name: Analyze
+        run: dart analyze --fatal-infos ${{ env.dir }}
+
+      - name: Check lints
+        run: dart format --output=none --set-exit-if-changed ${{ env.dir }}
+
+      - name: Publish --dry-run
+        working-directory: ${{ env.dir }}
+        run: dart pub publish --dry-run
+
+      - name: Publish package
+        working-directory: ${{ env.dir }}
+        run: dart pub publish --force

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-     dir: ${{ startsWith(github.ref_name, 'flutter') and packages/flutter or packages/dart }}
+     dir: ${{ startsWith(github.ref_name, 'flutter') and 'packages/flutter' or 'packages/dart' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -13,23 +13,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
-
       - name: Resolve packages
         run: dart pub get --directory ${{ env.dir }}
-
       - name: Analyze
         run: dart analyze --fatal-infos ${{ env.dir }}
-
-      - name: Check lints
+      - name: Check lint
         run: dart format --output=none --set-exit-if-changed ${{ env.dir }}
-
-      - name: Publish --dry-run
+      - name: Publish package (dry-run)
         working-directory: ${{ env.dir }}
         run: dart pub publish --dry-run
-
       - name: Publish package
         working-directory: ${{ env.dir }}
         run: dart pub publish --force

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,5 +1,4 @@
 name: release-automated
-
 on:
   push:
     tags:

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -6,7 +6,7 @@ on:
       - "dart-[0-9]+.[0-9]+.[0-9]+*"
       - "flutter-[0-9]+.[0-9]+.[0-9]+*"
 jobs:
-  release-flutter:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
      dir: ${{ startsWith(github.ref_name, 'flutter') and 'packages/flutter' or 'packages/dart' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -21,27 +21,31 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+     dir: ${{ github.event.inputs.package == 'flutter' and 'packages/flutter' or 'packages/dart' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
-      - name: Publish dart package
-        if: github.event.inputs.package == 'dart'
-        uses: k-paxian/dart-package-publisher@v1.5.1
-        with:
-          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-          relativePath: packages/dart
-          format: true
-          dryRunOnly: false
-      - name: Publish flutter package
-        if: github.event.inputs.package == 'flutter'
-        uses: k-paxian/dart-package-publisher@v1.5.1
-        with:
-          accessToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_ACCESS_TOKEN  }}
-          refreshToken: ${{ secrets.PUBDEV_GOOGLE_ACCOUNT_REFRESH_TOKEN }}
-          relativePath: packages/flutter
-          flutter: true
-          format: true
-          dryRunOnly: false
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Resolve packages
+        run: dart pub get --directory ${{ env.dir }}
+
+      - name: Analyze
+        run: dart analyze --fatal-infos ${{ env.dir }}
+
+      - name: Check lints
+        run: dart format --output=none --set-exit-if-changed ${{ env.dir }}
+
+      - name: Publish --dry-run
+        working-directory: ${{ env.dir }}
+        run: dart pub publish --dry-run
+
+      - name: Publish package
+        working-directory: ${{ env.dir }}
+        run: dart pub publish --force

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -29,23 +29,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
-
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
-
       - name: Resolve packages
         run: dart pub get --directory ${{ env.dir }}
-
       - name: Analyze
         run: dart analyze --fatal-infos ${{ env.dir }}
-
-      - name: Check lints
+      - name: Check lint
         run: dart format --output=none --set-exit-if-changed ${{ env.dir }}
-
-      - name: Publish --dry-run
+      - name: Publish package (dry-run)
         working-directory: ${{ env.dir }}
         run: dart pub publish --dry-run
-
       - name: Publish package
         working-directory: ${{ env.dir }}
         run: dart pub publish --force

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
      dir: ${{ github.event.inputs.package == 'flutter' and 'packages/flutter' or 'packages/dart' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #881

### Approach
<!-- Add a description of the approach in this PR. -->

Using the recommended solution by the Flutter team [publishing packages using GitHub actions](https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions)


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

@mtrezza There are some steps you need to do in the pub.dev admin tab to enable this.

On the Dart SDK admin tab add the following 
<img width=500 src=https://github.com/parse-community/Parse-SDK-Flutter/assets/29513372/88590e38-f422-4d5f-be0b-cc479cfad9e8/>
 

On the Flutter SDK admin tab add the following 
 
<img width=500 src=https://github.com/parse-community/Parse-SDK-Flutter/assets/29513372/0b56195f-4c63-4e0d-b4e3-0d6d6431fa9f/>
 

Make sure to follow this [hardening security with tag-protection rules on github](https://dart.dev/tools/pub/automated-publishing#hardening-security-with-tag-protection-rules-on-github)



- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] A changelog entry
