### PR TITLE
ci: Fix manual release workflow

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -3,7 +3,13 @@
 # part of the automated release workflow.
 
 name: release-manual
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Reference tag (dart-#.#.# or flutter-#.#.#):'
+        required: true
+        default: ''
 env:
   package: ${{ startsWith(github.event.ref, 'dart') && 'dart' || 'flutter' }}
 jobs:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

### Issue Description

Input fields missing for manual release workflow; these can be removed later so that only the tag needs to be chosen, but for Flutter 5.0.0 release, they are required.

Closes: #881 

### Approach
<!-- Add a description of the approach in this PR. -->

Add input tags in workflow.