### PR TITLE
docs: Fix license link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 ## Pull Request
 
 - Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
-- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/master/LICENSE).
+- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
 - Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).
 
 ## Issue


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue

License link incorrect.

Closes: #n/a