### PR TITLE
Fix malformed JSON in _buildQueryRelational

### DIFF
--- a/packages/dart/lib/src/network/parse_query.dart
+++ b/packages/dart/lib/src/network/parse_query.dart
@@ -454,7 +454,8 @@ class QueryBuilder<T extends ParseObject> {
   /// Builds the query relational for Parse
   String _buildQueryRelational(String className) {
     queries = _checkForMultipleColumnInstances(queries);
-    return '{"where":{${buildQueries(queries)}},"className":"$className",${getLimitersRelational(limiters)}}';
+    String lim = getLimitersRelational(limiters);
+    return '{"where":{${buildQueries(queries)}},"className":"$className"${limiters.isNotEmpty ? ',"$lim"' : ''}}';
   }
 
   /// Builds the query relational with Key for Parse


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
https://github.com/parse-community/Parse-SDK-Flutter/issues/939
Closes: #939

## Approach
<!-- Describe the changes in this PR. -->
Fix bug in JSON creation when `whereMatchesQuery` is used.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
