### PR TITLE
refactor: Update `connectivity_plus` to 4.0.1

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
 
   # Networking
   connectivity_plus: ^4.0.1
-  js: ^0.6.5
 
   #Database
   shared_preferences: ^2.1.2
@@ -37,6 +36,9 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   path_provider_platform_interface: ^2.0.6
   plugin_platform_interface: ^2.1.4
+
+dependency_overrides:
+  js: ^0.6.5
 
 screenshots:
   - description: Parse Platform logo.

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 
   # Networking
   connectivity_plus: ^4.0.1
+  js: ^0.6.5
 
   #Database
   shared_preferences: ^2.1.2

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   #   path: ../dart
 
   # Networking
-  connectivity_plus: ^3.0.6
+  connectivity_plus: ^4.0.1
 
   #Database
   shared_preferences: ^2.1.2


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue

Closes: [945](https://github.com/parse-community/Parse-SDK-Flutter/issues/945)

## Approach
<!-- Describe the changes in this PR. -->
Just updating connectivity_plus to latest version.
This should solve issues with using connectivity_plus and this package together in the same project.


