### PR TITLE
fix: Malformed JSON in `whereMatchesQuery`

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-5.1.2...dart-5.1.3) (2023-05-29)
+
+### Bug Fixes
+
+* Malformed JSON in `whereMatchesQuery` ([#955](https://github.com/parse-community/Parse-SDK-Flutter/pull/955))
+
 ## [5.1.2](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-5.1.1...dart-5.1.2) (2023-05-29)
 
 ### Bug Fixes

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [5.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-5.1.2...dart-5.1.3) (2023-05-29)
+## [5.1.3](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-5.1.2...dart-5.1.3) (2023-07-18)
 
 ### Bug Fixes
 

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of flutter_parse_sdk;
 
 // Library
-const String keySdkVersion = '5.1.2';
+const String keySdkVersion = '5.1.3';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/network/parse_query.dart
+++ b/packages/dart/lib/src/network/parse_query.dart
@@ -454,7 +454,8 @@ class QueryBuilder<T extends ParseObject> {
   /// Builds the query relational for Parse
   String _buildQueryRelational(String className) {
     queries = _checkForMultipleColumnInstances(queries);
-    return '{"where":{${buildQueries(queries)}},"className":"$className",${getLimitersRelational(limiters)}}';
+    String lim = getLimitersRelational(limiters);
+    return '{"where":{${buildQueries(queries)}},"className":"$className"${limiters.isNotEmpty ? ',"$lim"' : ''}}';
   }
 
   /// Builds the query relational with Key for Parse

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: The Dart SDK to connect to Parse Server. Build your apps faster with Parse Platform, the complete application stack.
-version: 5.1.2
+version: 5.1.3
 homepage: https://github.com/parse-community/Parse-SDK-Flutter
 
 environment:

--- a/packages/dart/test/src/network/parse_query_test.dart
+++ b/packages/dart/test/src/network/parse_query_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:parse_server_sdk/parse_server_sdk.dart';
@@ -463,7 +464,7 @@ void main() {
       )).captured.single);
 
       // assert
-      expect(result.query.contains("%22object2%22,%22include%22"), true);
+      expect(result.query.contains("%22object2%22,%22%22include%22"), true);
     });
 
     test('the result query should contains encoded special characters values',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Re-open PR: #943
Closes: #939

## Approach
<!-- Describe the changes in this PR. -->
Fix bug in JSON creation when `whereMatchesQuery` is used.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)

