### PR TITLE
fix: Conflict with v6.x of `connectivity_plus` dependency

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk_flutter
 description: The Flutter SDK to connect to Parse Server. Build your apps faster with Parse Platform, the complete application stack.
-version: 8.0.0
+version: 8.0.1
 homepage: https://parseplatform.org
 repository: https://github.com/parse-community/Parse-SDK-Flutter
 issue_tracker: https://github.com/parse-community/Parse-SDK-Flutter/issues
@@ -31,7 +31,7 @@ dependencies:
   #   path: ../dart
 
   # Networking
-  connectivity_plus: ^5.0.2
+  connectivity_plus: ^6.0.3
 
   #Database
   shared_preferences: ^2.2.2

--- a/packages/flutter/test/src/parse_server_sdk_flutter_test.dart
+++ b/packages/flutter/test/src/parse_server_sdk_flutter_test.dart
@@ -1,0 +1,227 @@
+@TestOn('dart-vm')
+@Timeout.factor(2)
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:parse_server_sdk_flutter/parse_server_sdk_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'storage/core_store_directory_io_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Parse parse;
+
+  setUp(() {
+    parse = Parse();
+    PackageInfo.setMockInitialValues(
+      appName: 'appName',
+      packageName: 'packageName',
+      version: '1.0',
+      buildNumber: '1',
+      buildSignature: 'buildSignature',
+    );
+    SharedPreferences.setMockInitialValues({});
+    PathProviderPlatform.instance = FakePathProviderPlatform();
+  });
+
+  group('Connectivity static checks', () {
+    test('Check when connectivity is None', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.none);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.none);
+    });
+
+    test('Check when connectivity is Wifi', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.wifi);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.wifi);
+    });
+
+    test('Check when connectivity is Mobile', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.mobile);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.mobile);
+    });
+
+    test('Check when connectivity is Mobile and VPN', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.vpn);
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.mobile);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.mobile);
+    });
+
+    test('Check when connectivity is Wifi + Mobile that Wifi is preferred', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.mobile);
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.wifi);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.wifi);
+    });
+
+    test('Check when connectivity is Other that we preserve old behavior that Wifi is assumed', () async {
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.other);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+
+      // sut
+      final result = await parse.checkConnectivity();
+
+      expect(result, ParseConnectivityResult.wifi);
+    });
+  });
+
+  group('Connectivity stream tests', () {
+    test('Update stream when connectivity changes to None', () async {
+      final completer = Completer<ParseConnectivityResult>();
+      final fakeConnectivity = FakeConnectivity();
+      fakeConnectivity.addConnectivityStatus(ConnectivityResult.mobile);
+      await parse.initialize(
+        'appId',
+        'serverUrl',
+        connectivity: fakeConnectivity,
+      );
+      parse.connectivityStream.listen((event) {
+        if (event == ParseConnectivityResult.none) {
+          completer.complete(event);
+        }
+      });
+
+      // sut - trigger event
+      fakeConnectivity.updateConnectivityStatus(ConnectivityResult.none);
+      final result = await completer.future;
+
+      // assert
+      expect(result, ParseConnectivityResult.none);
+    }, timeout: const Timeout(Duration(seconds: 1)));
+  });
+
+  test('Update stream when connectivity changes to Wifi', () async {
+    final completer = Completer<ParseConnectivityResult>();
+    final fakeConnectivity = FakeConnectivity();
+    fakeConnectivity.addConnectivityStatus(ConnectivityResult.none);
+    await parse.initialize(
+      'appId',
+      'serverUrl',
+      connectivity: fakeConnectivity,
+    );
+    parse.connectivityStream.listen((event) {
+      print('event: $event');
+      if (event == ParseConnectivityResult.wifi) {
+        completer.complete(event);
+      }
+    });
+
+    // sut - trigger event
+    fakeConnectivity.updateConnectivityStatus(ConnectivityResult.wifi);
+    final result = await completer.future;
+
+    // assert
+    expect(result, ParseConnectivityResult.wifi);
+  }, timeout: const Timeout(Duration(seconds: 1)));
+
+  test('Update stream when connectivity even though connectivity stayed the same', () async {
+    final completer = Completer<ParseConnectivityResult>();
+    final fakeConnectivity = FakeConnectivity();
+    fakeConnectivity.addConnectivityStatus(ConnectivityResult.mobile);
+    await parse.initialize(
+      'appId',
+      'serverUrl',
+      connectivity: fakeConnectivity,
+    );
+    parse.connectivityStream.listen((event) {
+      print('event: $event');
+      if (event == ParseConnectivityResult.mobile) {
+        completer.complete(event);
+      }
+    });
+
+    // sut - trigger event where mobile user joins VPN
+    fakeConnectivity.addConnectivityStatus(ConnectivityResult.vpn);
+    final result = await completer.future;
+
+    // assert that event was triggered but connectivity still says mobile
+    expect(result, ParseConnectivityResult.mobile);
+  }, timeout: const Timeout(Duration(seconds: 1)));
+}
+
+Connectivity get fakeConnectivity {
+  return FakeConnectivity();
+}
+
+class FakeConnectivity extends Fake implements Connectivity {
+  final List<ConnectivityResult> _results = List.empty(growable: true);
+  final StreamController<List<ConnectivityResult>> _streamController = StreamController.broadcast();
+
+  void updateConnectivityStatus(ConnectivityResult result) {
+    _results.clear();
+    addConnectivityStatus(result);
+  }
+
+  addConnectivityStatus(ConnectivityResult result) {
+    _results.add(result);
+    _streamController.sink.add(_results);
+  }
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    return _results;
+  }
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged {
+    return _streamController.stream;
+  }
+}


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue
#1001 

Closes: #1001

## Approach
Bumped `connectivity_plus` dependency to 6.0.3 (latest). They now return a list of connectivity results so I mapped those results to the `ParseConnectivityResult` enum and preserved old behavior.

I covered with new unit tests.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
