### PR TITLE
fix: Select input name instead of file in `ParseFile`

### DIFF
--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [7.0.1](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-7.0.0...dart-7.0.1) (2024-10-16)
+
+### Bug Fixes
+
+* Select input name instead of file in `ParseFile` ([#1012](https://github.com/parse-community/Parse-SDK-Flutter/pull/1012))
+
 ## [7.0.0](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-6.4.0...dart-7.0.0) (2024-04-12)
 
 ### BREAKING CHANGES

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of '../../parse_server_sdk.dart';
 
 // Library
-const String keySdkVersion = '7.0.0';
+const String keySdkVersion = '7.0.1';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/lib/src/objects/parse_file.dart
+++ b/packages/dart/lib/src/objects/parse_file.dart
@@ -11,7 +11,7 @@ class ParseFile extends ParseFileBase {
       super.client,
       super.autoSendSessionId})
       : super(
-          name: file != null ? path.basename(file.path) : name!,
+          name: name ?? path.basename(file?.path ?? ''),
         );
 
   File? file;

--- a/packages/dart/lib/src/objects/parse_x_file.dart
+++ b/packages/dart/lib/src/objects/parse_x_file.dart
@@ -11,7 +11,7 @@ class ParseXFile extends ParseFileBase {
       super.client,
       super.autoSendSessionId})
       : super(
-          name: file != null ? path.basename(file.path) : name!,
+          name: name ?? path.basename(file?.path ?? ''),
         );
 
   XFile? file;

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: The Dart SDK to connect to Parse Server. Build your apps faster with Parse Platform, the complete application stack.
-version: 7.0.0
+version: 7.0.1
 homepage: https://parseplatform.org
 repository: https://github.com/parse-community/Parse-SDK-Flutter
 issue_tracker: https://github.com/parse-community/Parse-SDK-Flutter/issues

--- a/packages/dart/test/src/objects/parse_file_test.dart
+++ b/packages/dart/test/src/objects/parse_file_test.dart
@@ -11,13 +11,8 @@ void main() {
 
   group('Parse X File', () {
     test('should return a correct name', () {
-      // arrange
       File file = File('/sdcard/aa/aa.jpg');
-
-      // act
       final parseFile = ParseFile(file, name: 'bb.jpg');
-
-      // assert
       expect(parseFile.name, 'bb.jpg');
     });
   });

--- a/packages/dart/test/src/objects/parse_file_test.dart
+++ b/packages/dart/test/src/objects/parse_file_test.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('Parse X File', () {
+    test('should return a correct name', () {
+      // arrange
+      File file = File('/sdcard/aa/aa.jpg');
+
+      // act
+      final parseFile = ParseFile(file, name: 'bb.jpg');
+
+      // assert
+      expect(parseFile.name, 'bb.jpg');
+    });
+  });
+}

--- a/packages/dart/test/src/objects/parse_x_file_test.dart
+++ b/packages/dart/test/src/objects/parse_x_file_test.dart
@@ -1,0 +1,24 @@
+import 'package:cross_file/cross_file.dart';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('Parse X File', () {
+    test('should return a correct name', () {
+      // arrange
+      XFile file = XFile('/sdcard/aa/aa.jpg');
+
+      // act
+      final parseFile = ParseXFile(file, name: 'bb.jpg');
+
+      // assert
+      expect(parseFile.name, 'bb.jpg');
+    });
+  });
+}

--- a/packages/dart/test/src/objects/parse_x_file_test.dart
+++ b/packages/dart/test/src/objects/parse_x_file_test.dart
@@ -11,13 +11,8 @@ void main() {
 
   group('Parse X File', () {
     test('should return a correct name', () {
-      // arrange
       XFile file = XFile('/sdcard/aa/aa.jpg');
-
-      // act
       final parseFile = ParseXFile(file, name: 'bb.jpg');
-
-      // assert
       expect(parseFile.name, 'bb.jpg');
     });
   });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue
Select the file name from the input name instead of file

Closes: #1011

## Approach
n/a

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
