### PR TITLE
fix: Add support for Dart `3.4`, `3.5`; remove support for Dart `3.0`,`3.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,25 +16,25 @@ jobs:
         include:
           # Dart framework may contain breaking changes in minor version releases, not following semver.
           # The latest Dart framework (below) is tested on all architectures (Ubuntu, macOS, Windows).
-          - name: Dart 3.3, Ubuntu
+          - name: Dart 3.5, Ubuntu
             os: ubuntu-latest
-            sdk: 3.3.3
-          - name: Dart 3.3, macOS
+            sdk: 3.5.3
+          - name: Dart 3.5, macOS
             os: macos-latest
-            sdk: 3.3.3
-          - name: Dart 3.3, Windows
+            sdk: 3.5.3
+          - name: Dart 3.5, Windows
             os: windows-latest
-            sdk: 3.3.3
+            sdk: 3.5.3
           # Older Dart framework versions (below) are only tested with Ubuntu to reduce CI resource usage.
+          - name: Dart 3.4
+            os: ubuntu-latest
+            sdk: 3.4.4
+          - name: Dart 3.3
+            os: ubuntu-latest
+            sdk: 3.3.4
           - name: Dart 3.2
             os: ubuntu-latest
             sdk: 3.2.6
-          - name: Dart 3.1
-            os: ubuntu-latest
-            sdk: 3.1.5
-          - name: Dart 3.0
-            os: ubuntu-latest
-            sdk: 3.0.7
           - name: Dart beta
             os: ubuntu-latest
             sdk: beta

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [8.0.0](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-7.0.1...dart-8.0.0) (2024-10-17)
+
+### BREAKING CHANGES
+
+* This release removes support for Dart 3.0,3.1 ([#993](https://github.com/parse-community/Parse-SDK-Flutter/pull/993))
+
+### Features
+
+* Add support for Dart 3.4, 3.5; remove support for Dart 3.0,3.1 ([#993](https://github.com/parse-community/Parse-SDK-Flutter/pull/993))
+
 ## [7.0.1](https://github.com/parse-community/Parse-SDK-Flutter/compare/dart-7.0.0...dart-7.0.1) (2024-10-16)
 
 ### Bug Fixes

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -32,10 +32,10 @@ The Parse Dart SDK is continuously tested with the most recent release of the Da
 
 | Version   | Latest Version | End of Support | Compatible |
 |-----------|----------------|----------------|------------|
-| Dart 3.3  | 3.3.3          | Mar 2025       | ✅ Yes      |
 | Dart 3.2  | 3.2.6          | Jan 2025       | ✅ Yes      |
-| Dart 3.1  | 3.1.5          | Oct 2024       | ✅ Yes      |
-| Dart 3.0  | 3.0.7          | May 2024       | ✅ Yes      |
+| Dart 3.3  | 3.3.4          | Apr 2025       | ✅ Yes      |
+| Dart 3.4  | 3.4.4          | Jun 2025       | ✅ Yes      |
+| Dart 3.5  | 3.5.3          | Sep 2025       | ✅ Yes      |
 
 ## Getting Started
 

--- a/packages/dart/lib/src/base/parse_constants.dart
+++ b/packages/dart/lib/src/base/parse_constants.dart
@@ -1,7 +1,7 @@
 part of '../../parse_server_sdk.dart';
 
 // Library
-const String keySdkVersion = '7.0.1';
+const String keySdkVersion = '8.0.0';
 const String keyLibraryName = 'Flutter Parse SDK';
 
 // End Points

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_server_sdk
 description: The Dart SDK to connect to Parse Server. Build your apps faster with Parse Platform, the complete application stack.
-version: 7.0.1
+version: 8.0.0
 homepage: https://parseplatform.org
 repository: https://github.com/parse-community/Parse-SDK-Flutter
 issue_tracker: https://github.com/parse-community/Parse-SDK-Flutter/issues
@@ -18,36 +18,36 @@ topics:
   - backend
 
 environment:
-  sdk: ">=3.0.7 <4.0.0"
+  sdk: ">=3.2.6 <4.0.0"
 
 dependencies:
   # Networking
-  dio: ^5.4.2+1
-  http: ^1.1.0
-  web_socket_channel: ^2.4.0
+  dio: ^5.7.0
+  http: ^1.2.0
+  web_socket_channel: ^2.4.3
 
   #Database
   sembast: ^3.6.0
   sembast_web: ^2.2.0
 
   # Utils
-  uuid: ^4.3.3
-  meta: ^1.12.0
+  uuid: ^4.5.1
+  meta: ^1.16.0
   path: ^1.9.0
-  mime: ^1.0.4
-  timezone: ^0.9.2
+  mime: ^2.0.0
+  timezone: ^0.9.4
   universal_io: ^2.2.2
   xxtea: ^2.1.0
   collection: ^1.18.0
-  cross_file: ^0.3.3+7
+  cross_file: ^0.3.3+8
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0
 
   # Testing
   build_runner: ^2.4.9
-  mockito: ^5.4.2
-  test: ^1.24.9
+  mockito: ^5.4.4
+  test: ^1.25.7
 
 screenshots:
   - description: Parse Platform logo.


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-Flutter/issues?q=is%3Aissue).

## Issue
Add support for Dart `3.4`, `3.5` and remove support for Dart `3.0`,`3.1`

Closes: n/a

## Approach
n/a

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
