### PR TITLE
feat: Expose `ParseDioClient.additionalHeaders` to set additional custom headers applied to all requests

### DIFF
--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -32,6 +32,15 @@ class ParseDioClient extends ParseClient {
 
   dio.Dio get client => _client;
 
+  /// Custom headers to include in every request made by this client.
+  ///
+  /// This mirrors the same functionality already exposed by [ParseHTTPClient].
+  /// The internal [_ParseDioClient] reads these headers in its [request]
+  /// override and merges them into every outgoing request.
+  Map<String, String>? get additionalHeaders => _client.additionalHeaders;
+  set additionalHeaders(Map<String, String>? additionalHeaders) =>
+      _client.additionalHeaders = additionalHeaders;
+
   @override
   Future<ParseNetworkResponse> get(
     String path, {

--- a/packages/dart/test/src/network/parse_dio_client_test.dart
+++ b/packages/dart/test/src/network/parse_dio_client_test.dart
@@ -24,5 +24,34 @@ void main() {
       expect(dioClient, isNotNull);
       expect(dioClient, isA<Dio>());
     });
+
+    test('additionalHeaders should be null by default', () {
+      expect(parseDioClient.additionalHeaders, isNull);
+    });
+
+    test('should set and get additionalHeaders', () {
+      // arrange
+      final headers = {'X-Custom-Header': 'test-value', 'X-Another': 'value2'};
+
+      // act
+      parseDioClient.additionalHeaders = headers;
+
+      // assert
+      expect(parseDioClient.additionalHeaders, equals(headers));
+      expect(parseDioClient.additionalHeaders!['X-Custom-Header'], 'test-value');
+      expect(parseDioClient.additionalHeaders!['X-Another'], 'value2');
+    });
+
+    test('should allow clearing additionalHeaders by setting to null', () {
+      // arrange
+      parseDioClient.additionalHeaders = {'X-Header': 'value'};
+      expect(parseDioClient.additionalHeaders, isNotNull);
+
+      // act
+      parseDioClient.additionalHeaders = null;
+
+      // assert
+      expect(parseDioClient.additionalHeaders, isNull);
+    });
   });
 }

--- a/packages/dart/test/src/network/parse_dio_client_test.dart
+++ b/packages/dart/test/src/network/parse_dio_client_test.dart
@@ -38,7 +38,10 @@ void main() {
 
       // assert
       expect(parseDioClient.additionalHeaders, equals(headers));
-      expect(parseDioClient.additionalHeaders!['X-Custom-Header'], 'test-value');
+      expect(
+        parseDioClient.additionalHeaders!['X-Custom-Header'],
+        'test-value',
+      );
       expect(parseDioClient.additionalHeaders!['X-Another'], 'value2');
     });
 


### PR DESCRIPTION
## New Feature

`ParseHTTPClient` already exposes `additionalHeaders` via a public getter/setter, allowing developers to inject custom headers into every request. However, `ParseDioClient` does not expose this, even though the internal `_ParseDioClient` class fully supports it — it reads `additionalHeaders` in its `request()` override and merges them into every outgoing request.

This adds the same 2-line getter/setter forwarding to `ParseDioClient`, bringing it to parity with `ParseHTTPClient`.

### Motivation

Developers who need `ParseDioClient` (e.g., to work around TLS/HandshakeException issues on Android) currently cannot set custom headers without modifying the package source. This small change enables use cases like adding diagnostic or telemetry headers to all Parse requests.

### Changes

- Added `additionalHeaders` getter/setter to `ParseDioClient` that forwards to the internal `_ParseDioClient.additionalHeaders` field

### Example

```dart
final client = ParseDioClient(sendSessionId: true);
client.additionalHeaders = {
  'X-Custom-Header': 'value',
};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed client-level custom headers on the HTTP client so users can set headers applied to all requests; headers can be set, read back, and cleared.
* **Tests**
  * Added unit tests validating default state, setting/retrieving headers (including nested access), and clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->