### PR TITLE
refactor: Bump codecov/codecov-action from 5 to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage -i coverage/test -o coverage/lcov.info --lcov --packages=.dart_tool/package_config.json --report-on=lib
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         with:
@@ -141,7 +141,7 @@ jobs:
           escapedPath="$(echo `pwd` | sed 's/\//\\\//g')"
           sed "s/^SF:lib/SF:$escapedPath\/lib/g" coverage/lcov.info > coverage/lcov-full.info
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         with:


### PR DESCRIPTION
Closes #1120

### Changes

- **v6.0.0**: Updated internal runtime from node20 to node24. Bumped `actions/github-script` from v7 to v8. No changes to action inputs, outputs, or behavior.

### Breaking Changes

None — the node24 requirement is already supported by GitHub Actions runners.

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting infrastructure to the latest stable version for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->