### PR TITLE
ci: Replace third-party GitHub Actions with trusted alternatives

### DIFF
--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -17,6 +17,12 @@ jobs:
     if: github.event.inputs.tag != ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,9 +42,12 @@ jobs:
         run: dart pub get --directory 'packages/flutter'
       - name: Generate Docs
         run: dart doc ./packages/${{ env.package }}/ -o ./.api_docs/${{ env.package }}/
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.0.0
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./.api_docs/${{ env.package }}/
-          destination_dir: ${{ env.package }}
+          path: ./.api_docs/${{ env.package }}/
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -76,6 +76,12 @@ jobs:
     needs: pub-publish-dart
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -87,18 +93,27 @@ jobs:
         run: dart pub get --directory 'packages/dart'
       - name: Generate Docs
         run: dart doc ./packages/dart/ -o ./.api_docs/dart/
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.0.0
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./.api_docs/dart/
-          destination_dir: dart
+          path: ./.api_docs/dart/
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
 
   docs-publish-flutter:
     if: startsWith(github.ref_name, 'flutter-')
     needs: pub-publish-flutter
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -117,9 +132,12 @@ jobs:
         run: dart pub get --directory 'packages/flutter'
       - name: Generate Docs
         run: dart doc ./packages/flutter/ -o ./.api_docs/flutter/
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.0.0
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./.api_docs/flutter/
-          destination_dir: flutter
+          path: ./.api_docs/flutter/
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Replace untrusted third-party GitHub Actions with official alternatives to reduce supply chain attack surface.

## Changes
- Replace `peaceiris/actions-gh-pages` with official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` pipeline

## Note
The repository Pages source setting must be changed to "GitHub Actions" in Settings > Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing workflows to use GitHub's official Pages deployment actions, replacing the previous third-party publishing approach for improved security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->