### PR TITLE
ci: Add missing contents: read permission for checkout

### DIFF
--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:
@@ -109,6 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
## Summary
Add missing `contents: read` permission to jobs that deploy to GitHub Pages.

When a job declares an explicit `permissions:` block, all default permissions are revoked. The `actions/checkout` action requires `contents: read` to access the repository. Without it, checkout may fail in private repos or when the token is used for authenticated operations.

## Changes
- Add `contents: read` to permissions in `release-manual-docs.yml` (docs-publish job)
- Add `contents: read` to permissions in `release-publish.yml` (docs-publish-dart and docs-publish-flutter jobs)