### PR TITLE
feat: Multiple SDK-level fixes for anonymous-to-password conversion (iOS parity)

### DIFF
--- a/packages/dart/lib/src/network/options.dart
+++ b/packages/dart/lib/src/network/options.dart
@@ -1,9 +1,14 @@
 part of '../../parse_server_sdk.dart';
 
 class ParseNetworkOptions {
-  ParseNetworkOptions({this.headers});
+  ParseNetworkOptions({this.headers, this.sendInstallationId});
 
   final Map<String, String>? headers;
+
+  /// When `false`, the client suppresses the `X-Parse-Installation-Id`
+  /// header for this request. `null` (the default) lets the client attach
+  /// the header — matching iOS PFURLSessionCommandRunner behaviour.
+  final bool? sendInstallationId;
   // final ParseNetworkResponseType responseType;
 }
 

--- a/packages/dart/lib/src/network/parse_client.dart
+++ b/packages/dart/lib/src/network/parse_client.dart
@@ -69,6 +69,33 @@ abstract class ParseClient {
 
   @Deprecated("Use ParseCoreData() instead.")
   ParseCoreData get data => ParseCoreData();
+
+  /// Returns `options.headers` with `X-Parse-Installation-Id` attached unless
+  /// the caller opted out via `ParseNetworkOptions.sendInstallationId = false`
+  /// or the header is already set. Installation lookup failures fall through
+  /// silently — a network call should not fail because the install ID could
+  /// not be read.
+  @protected
+  Future<Map<String, String>?> buildHeaders(
+    ParseNetworkOptions? options,
+  ) async {
+    if (options?.sendInstallationId == false) return options?.headers;
+    if (options?.headers?[keyHeaderInstallationId] != null) {
+      return options?.headers;
+    }
+    String? installationId;
+    try {
+      installationId =
+          (await ParseInstallation.currentInstallation()).installationId;
+    } catch (_) {
+      return options?.headers;
+    }
+    if (installationId == null) return options?.headers;
+    return <String, String>{
+      ...?options?.headers,
+      keyHeaderInstallationId: installationId,
+    };
+  }
 }
 
 /// Callback to listen the progress for sending/receiving data.

--- a/packages/dart/lib/src/network/parse_dio_client.dart
+++ b/packages/dart/lib/src/network/parse_dio_client.dart
@@ -47,12 +47,13 @@ class ParseDioClient extends ParseClient {
     ParseNetworkOptions? options,
     ProgressCallback? onReceiveProgress,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
           final dio.Response<String> dioResponse = await _client.get<String>(
             path,
-            options: _Options(headers: options?.headers),
+            options: _Options(headers: headers),
           );
 
           return ParseNetworkResponse(
@@ -76,6 +77,7 @@ class ParseDioClient extends ParseClient {
     ProgressCallback? onReceiveProgress,
     dynamic cancelToken,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
@@ -85,7 +87,7 @@ class ParseDioClient extends ParseClient {
                 cancelToken: cancelToken,
                 onReceiveProgress: onReceiveProgress,
                 options: _Options(
-                  headers: options?.headers,
+                  headers: headers,
                   responseType: dio.ResponseType.bytes,
                 ),
               );
@@ -116,6 +118,7 @@ class ParseDioClient extends ParseClient {
     String? data,
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -123,7 +126,7 @@ class ParseDioClient extends ParseClient {
           final dio.Response<String> dioResponse = await _client.put<String>(
             path,
             data: data,
-            options: _Options(headers: options?.headers),
+            options: _Options(headers: headers),
           );
 
           return ParseNetworkResponse(
@@ -146,6 +149,7 @@ class ParseDioClient extends ParseClient {
     String? data,
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -153,7 +157,7 @@ class ParseDioClient extends ParseClient {
           final dio.Response<String> dioResponse = await _client.post<String>(
             path,
             data: data,
-            options: _Options(headers: options?.headers),
+            options: _Options(headers: headers),
           );
 
           return ParseNetworkResponse(
@@ -178,6 +182,7 @@ class ParseDioClient extends ParseClient {
     ProgressCallback? onSendProgress,
     dynamic cancelToken,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -186,7 +191,7 @@ class ParseDioClient extends ParseClient {
             path,
             data: data,
             cancelToken: cancelToken,
-            options: _Options(headers: options?.headers),
+            options: _Options(headers: headers),
             onSendProgress: onSendProgress,
           );
 
@@ -235,12 +240,13 @@ class ParseDioClient extends ParseClient {
     String path, {
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
           final dio.Response<String> dioResponse = await _client.delete<String>(
             path,
-            options: _Options(headers: options?.headers),
+            options: _Options(headers: headers),
           );
 
           return ParseNetworkResponse(

--- a/packages/dart/lib/src/network/parse_http_client.dart
+++ b/packages/dart/lib/src/network/parse_http_client.dart
@@ -47,12 +47,13 @@ class ParseHTTPClient extends ParseClient {
     ParseNetworkOptions? options,
     ProgressCallback? onReceiveProgress,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
           final http.Response response = await _client.get(
             Uri.parse(path),
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkResponse(
             data: response.body,
@@ -75,12 +76,13 @@ class ParseHTTPClient extends ParseClient {
     ProgressCallback? onReceiveProgress,
     dynamic cancelToken,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
           final http.Response response = await _client.get(
             Uri.parse(path),
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkByteResponse(
             bytes: response.bodyBytes,
@@ -102,6 +104,7 @@ class ParseHTTPClient extends ParseClient {
     String? data,
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -109,7 +112,7 @@ class ParseHTTPClient extends ParseClient {
           final http.Response response = await _client.put(
             Uri.parse(path),
             body: data,
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkResponse(
             data: response.body,
@@ -131,6 +134,7 @@ class ParseHTTPClient extends ParseClient {
     String? data,
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -138,7 +142,7 @@ class ParseHTTPClient extends ParseClient {
           final http.Response response = await _client.post(
             Uri.parse(path),
             body: data,
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkResponse(
             data: response.body,
@@ -162,6 +166,7 @@ class ParseHTTPClient extends ParseClient {
     ProgressCallback? onSendProgress,
     dynamic cancelToken,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       isWriteOperation: true,
       operation: () async {
@@ -174,7 +179,7 @@ class ParseHTTPClient extends ParseClient {
               (List<int> previous, List<int> element) =>
                   previous..addAll(element),
             ),
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkResponse(
             data: response.body,
@@ -195,12 +200,13 @@ class ParseHTTPClient extends ParseClient {
     String path, {
     ParseNetworkOptions? options,
   }) async {
+    final Map<String, String>? headers = await buildHeaders(options);
     return executeWithRetry(
       operation: () async {
         try {
           final http.Response response = await _client.delete(
             Uri.parse(path),
-            headers: options?.headers,
+            headers: headers,
           );
           return ParseNetworkResponse(
             data: response.body,

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -303,7 +303,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         ),
         data: jsonEncode(<String, dynamic>{
           'authData': <String, dynamic>{
-            'anonymous': <String, dynamic>{'id': uuid.v4()},
+            _keyAuthAnonymous: <String, dynamic>{'id': uuid.v4()},
           },
         }),
       );

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -503,8 +503,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
     if (objectId == null) {
       return await signUp();
     } else {
+      final String? tokenBefore = sessionToken;
       final ParseResponse response = await super.save();
       if (response.success) {
+        _adoptResponseSessionTokenIfChanged(tokenBefore);
         _cleanUpAuthData();
         await _onResponseSuccess();
       }
@@ -517,13 +519,28 @@ class ParseUser extends ParseObject implements ParseCloneable {
     if (objectId == null) {
       return await signUp();
     } else {
+      final String? tokenBefore = sessionToken;
       final ParseResponse response = await super.update();
       if (response.success) {
+        _adoptResponseSessionTokenIfChanged(tokenBefore);
         _cleanUpAuthData();
         await _onResponseSuccess();
       }
       return response;
     }
+  }
+
+  /// Adopt a new sessionToken from a save/update response. Parse Server
+  /// mints a fresh session when `password` is set on an existing _User
+  /// (revokeSessionOnPasswordReset, default true since 9.x); the prior
+  /// session is destroyed server-side, so the global session must be
+  /// updated or subsequent requests will fail with invalidSessionToken.
+  /// Mirrors iOS PFUser's _mergeFromServerWithResult.
+  void _adoptResponseSessionTokenIfChanged(String? tokenBefore) {
+    final String? tokenAfter = sessionToken;
+    if (tokenAfter == null || tokenAfter.isEmpty) return;
+    if (tokenAfter == tokenBefore) return;
+    ParseCoreData().setSessionId(tokenAfter);
   }
 
   Future<void> _onResponseSuccess() async {

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -220,15 +220,11 @@ class ParseUser extends ParseObject implements ParseCloneable {
       final Uri url = getSanitisedUri(_client, path);
       final String body = json.encode(toJson(forApiRQ: true));
       _saveChanges();
-      final String? installationId = await _getInstallationId();
       final ParseNetworkResponse response = await _client.post(
         url.toString(),
         options: ParseNetworkOptions(
-          headers: <String, String>{
-            keyHeaderRevocableSession: '1',
-            if (installationId != null && !doNotSendInstallationID)
-              keyHeaderInstallationId: installationId,
-          },
+          headers: <String, String>{keyHeaderRevocableSession: '1'},
+          sendInstallationId: !doNotSendInstallationID,
         ),
         data: body,
       );
@@ -259,18 +255,14 @@ class ParseUser extends ParseObject implements ParseCloneable {
         keyVarUsername: username!,
         keyVarPassword: password!,
       };
-      final String? installationId = await _getInstallationId();
       final Uri url = getSanitisedUri(_client, keyEndPointLogin);
       _saveChanges();
       final ParseNetworkResponse response = await _client.post(
         url.toString(),
         data: jsonEncode(queryParams),
         options: ParseNetworkOptions(
-          headers: <String, String>{
-            keyHeaderRevocableSession: '1',
-            if (installationId != null && !doNotSendInstallationID)
-              keyHeaderInstallationId: installationId,
-          },
+          headers: <String, String>{keyHeaderRevocableSession: '1'},
+          sendInstallationId: !doNotSendInstallationID,
         ),
       );
 
@@ -302,16 +294,12 @@ class ParseUser extends ParseObject implements ParseCloneable {
     try {
       final Uri url = getSanitisedUri(_client, keyEndPointUsers);
       const Uuid uuid = Uuid();
-      final String? installationId = await _getInstallationId();
 
       final ParseNetworkResponse response = await _client.post(
         url.toString(),
         options: ParseNetworkOptions(
-          headers: <String, String>{
-            keyHeaderRevocableSession: '1',
-            if (installationId != null && !doNotSendInstallationID)
-              keyHeaderInstallationId: installationId,
-          },
+          headers: <String, String>{keyHeaderRevocableSession: '1'},
+          sendInstallationId: !doNotSendInstallationID,
         ),
         data: jsonEncode(<String, dynamic>{
           'authData': <String, dynamic>{
@@ -366,17 +354,13 @@ class ParseUser extends ParseObject implements ParseCloneable {
   }) async {
     try {
       final Uri url = getSanitisedUri(_client, keyEndPointUsers);
-      final String? installationId = await _getInstallationId();
       final Map<String, dynamic> body = toJson(forApiRQ: true);
       body['authData'] = <String, dynamic>{provider: authData};
       final ParseNetworkResponse response = await _client.post(
         url.toString(),
         options: ParseNetworkOptions(
-          headers: <String, String>{
-            keyHeaderRevocableSession: '1',
-            if (installationId != null && !doNotSendInstallationID)
-              keyHeaderInstallationId: installationId,
-          },
+          headers: <String, String>{keyHeaderRevocableSession: '1'},
+          sendInstallationId: !doNotSendInstallationID,
         ),
         data: jsonEncode(body),
       );
@@ -696,10 +680,4 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   static ParseUser _getEmptyUser() =>
       ParseCoreData.instance.createParseUser(null, null, null);
-
-  static Future<String?> _getInstallationId() async {
-    final ParseInstallation parseInstallation =
-        await ParseInstallation.currentInstallation();
-    return parseInstallation.installationId;
-  }
 }

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -516,7 +516,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   /// Adopt a new sessionToken from a save/update response. Parse Server
   /// mints a fresh session when `password` is set on an existing _User
-  /// (revokeSessionOnPasswordReset, default true since 9.x); the prior
+  /// (revokeSessionOnPasswordReset, current default in 9.x); the prior
   /// session is destroyed server-side, so the global session must be
   /// updated or subsequent requests will fail with invalidSessionToken.
   /// Mirrors iOS PFUser's _mergeFromServerWithResult.

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -541,7 +541,11 @@ class ParseUser extends ParseObject implements ParseCloneable {
     } else {
       authData[_keyAuthAnonymous] = null;
     }
-    _unsavedChanges[keyVarAuthData] = authData;
+    if (authData.isEmpty) {
+      _unsavedChanges.remove(keyVarAuthData);
+    } else {
+      _unsavedChanges[keyVarAuthData] = authData;
+    }
   }
 
   void _cleanUpAuthData() {

--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -43,6 +43,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
   static const String keyUsername = 'username';
   static const String keyEmailAddress = 'email';
   static const String path = '$keyEndPointClasses$keyClassUser';
+  static const String _keyAuthAnonymous = 'anonymous';
 
   String? _password;
 
@@ -70,7 +71,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   String? get username => super.get<String>(keyVarUsername);
 
-  set username(String? username) => set<String?>(keyVarUsername, username);
+  set username(String? username) {
+    _stripAnonymity();
+    set<String?>(keyVarUsername, username);
+  }
 
   String? get emailAddress => super.get<String>(keyVarEmail);
 
@@ -282,7 +286,13 @@ class ParseUser extends ParseObject implements ParseCloneable {
     }
   }
 
-  /// Logs in a user anonymously
+  /// Logs in a user anonymously.
+  ///
+  /// To convert the resulting anonymous user into a permanent account,
+  /// set `username` and `password` on the [ParseUser] and call [save].
+  /// The anonymous provider is unlinked server-side and the local
+  /// `authData` is reconciled automatically.
+  ///
   /// Set [doNotSendInstallationID] to 'true' in order to prevent the SDK from sending the installationID to the Server.
   /// This option is especially useful if you are running you application on web and you don't have permission to add 'X-Parse-Installation-Id' as an allowed header on your parse-server.
   Future<ParseResponse> loginAnonymous({
@@ -495,6 +505,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
     } else {
       final ParseResponse response = await super.save();
       if (response.success) {
+        _cleanUpAuthData();
         await _onResponseSuccess();
       }
       return response;
@@ -508,6 +519,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
     } else {
       final ParseResponse response = await super.update();
       if (response.success) {
+        _cleanUpAuthData();
         await _onResponseSuccess();
       }
       return response;
@@ -516,6 +528,39 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   Future<void> _onResponseSuccess() async {
     await saveInStorage(keyParseStoreUser);
+  }
+
+  void _stripAnonymity() {
+    final Map<String, dynamic>? authData =
+        _objectData[keyVarAuthData] as Map<String, dynamic>?;
+    if (authData == null || !authData.containsKey(_keyAuthAnonymous)) {
+      return;
+    }
+    if (objectId == null) {
+      authData.remove(_keyAuthAnonymous);
+    } else {
+      authData[_keyAuthAnonymous] = null;
+    }
+    _unsavedChanges[keyVarAuthData] = authData;
+  }
+
+  void _cleanUpAuthData() {
+    final Map<String, dynamic>? authData =
+        _objectData[keyVarAuthData] as Map<String, dynamic>?;
+    if (authData != null) {
+      authData.removeWhere((_, dynamic value) => value == null);
+      if (authData.isEmpty) {
+        _objectData.remove(keyVarAuthData);
+      }
+    }
+    final Map<String, dynamic>? dirty =
+        _unsavedChanges[keyVarAuthData] as Map<String, dynamic>?;
+    if (dirty != null) {
+      dirty.removeWhere((_, dynamic value) => value == null);
+      if (dirty.isEmpty) {
+        _unsavedChanges.remove(keyVarAuthData);
+      }
+    }
   }
 
   /// Removes a user from Parse Server locally and online

--- a/packages/dart/test/src/network/parse_client_retry_integration_test.mocks.dart
+++ b/packages/dart/test/src/network/parse_client_retry_integration_test.mocks.dart
@@ -209,4 +209,14 @@ class MockParseClient extends _i1.Mock implements _i2.ParseClient {
             ),
           )
           as _i3.Future<_i2.ParseNetworkByteResponse>);
+
+  @override
+  _i3.Future<Map<String, String>?> buildHeaders(
+    _i2.ParseNetworkOptions? options,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#buildHeaders, [options]),
+            returnValue: _i3.Future<Map<String, String>?>.value(),
+          )
+          as _i3.Future<Map<String, String>?>);
 }

--- a/packages/dart/test/src/network/parse_client_test.dart
+++ b/packages/dart/test/src/network/parse_client_test.dart
@@ -1,0 +1,139 @@
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+/// Minimal concrete subclass for exercising methods on the abstract
+/// [ParseClient]. All HTTP methods throw — the test suite only targets the
+/// inherited helpers (`buildHeaders`) and never dispatches a real request.
+class _StubParseClient extends ParseClient {
+  @override
+  Future<ParseNetworkResponse> get(
+    String path, {
+    ParseNetworkOptions? options,
+    ProgressCallback? onReceiveProgress,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ParseNetworkResponse> put(
+    String path, {
+    String? data,
+    ParseNetworkOptions? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ParseNetworkResponse> post(
+    String path, {
+    String? data,
+    ParseNetworkOptions? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ParseNetworkResponse> postBytes(
+    String path, {
+    Stream<List<int>>? data,
+    ParseNetworkOptions? options,
+    ProgressCallback? onSendProgress,
+    dynamic cancelToken,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ParseNetworkResponse> delete(
+    String path, {
+    ParseNetworkOptions? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ParseNetworkByteResponse> getBytes(
+    String path, {
+    ParseNetworkOptions? options,
+    ProgressCallback? onReceiveProgress,
+    dynamic cancelToken,
+  }) => throw UnimplementedError();
+
+  // Exposes the protected helper so tests can call it without subclass tricks.
+  Future<Map<String, String>?> exposedBuildHeaders(
+    ParseNetworkOptions? options,
+  ) => buildHeaders(options);
+}
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('ParseClient.buildHeaders — X-Parse-Installation-Id handling', () {
+    late _StubParseClient client;
+
+    setUp(() {
+      client = _StubParseClient();
+    });
+
+    test(
+      'attaches X-Parse-Installation-Id by default. Matches iOS '
+      'PFURLSessionCommandRunner behaviour — every request carries the '
+      'install ID so parse-server can bind created _Session rows to the '
+      'right installation and so destroyDuplicatedSessions can clean up '
+      'prior sessions on the same install during login',
+      () async {
+        final Map<String, String>? headers = await client.exposedBuildHeaders(
+          null,
+        );
+
+        expect(headers, isNotNull);
+        expect(headers![keyHeaderInstallationId], isNotEmpty);
+      },
+    );
+
+    test(
+      'omits X-Parse-Installation-Id when caller passes '
+      'sendInstallationId: false. The opt-out is forwarded by methods such '
+      'as ParseUser.signUp(doNotSendInstallationID: true) for callers that '
+      'cannot allow-list the header on their parse-server',
+      () async {
+        final Map<String, String>? headers = await client.exposedBuildHeaders(
+          ParseNetworkOptions(sendInstallationId: false),
+        );
+
+        expect(
+          headers?[keyHeaderInstallationId],
+          isNull,
+          reason:
+              'sendInstallationId=false must suppress the header even when '
+              'an install ID is available',
+        );
+      },
+    );
+
+    test(
+      'preserves a caller-supplied X-Parse-Installation-Id rather than '
+      'overwriting it. Lets advanced callers (tests, multi-tenant proxies) '
+      'inject a specific install ID without the client clobbering it',
+      () async {
+        final Map<String, String>? headers = await client.exposedBuildHeaders(
+          ParseNetworkOptions(
+            headers: <String, String>{keyHeaderInstallationId: 'caller-id'},
+          ),
+        );
+
+        expect(headers![keyHeaderInstallationId], equals('caller-id'));
+      },
+    );
+
+    test(
+      'merges caller-supplied headers with the install ID. Custom headers '
+      'and the auto-attached install ID must coexist — neither side '
+      'overrides the other',
+      () async {
+        final Map<String, String>? headers = await client.exposedBuildHeaders(
+          ParseNetworkOptions(
+            headers: <String, String>{'X-Custom': 'value'},
+          ),
+        );
+
+        expect(headers!['X-Custom'], equals('value'));
+        expect(headers[keyHeaderInstallationId], isNotEmpty);
+      },
+    );
+  });
+}

--- a/packages/dart/test/src/network/parse_client_test.dart
+++ b/packages/dart/test/src/network/parse_client_test.dart
@@ -69,41 +69,35 @@ void main() {
       client = _StubParseClient();
     });
 
-    test(
-      'attaches X-Parse-Installation-Id by default. Matches iOS '
-      'PFURLSessionCommandRunner behaviour — every request carries the '
-      'install ID so parse-server can bind created _Session rows to the '
-      'right installation and so destroyDuplicatedSessions can clean up '
-      'prior sessions on the same install during login',
-      () async {
-        final Map<String, String>? headers = await client.exposedBuildHeaders(
-          null,
-        );
+    test('attaches X-Parse-Installation-Id by default. Matches iOS '
+        'PFURLSessionCommandRunner behaviour — every request carries the '
+        'install ID so parse-server can bind created _Session rows to the '
+        'right installation and so destroyDuplicatedSessions can clean up '
+        'prior sessions on the same install during login', () async {
+      final Map<String, String>? headers = await client.exposedBuildHeaders(
+        null,
+      );
 
-        expect(headers, isNotNull);
-        expect(headers![keyHeaderInstallationId], isNotEmpty);
-      },
-    );
+      expect(headers, isNotNull);
+      expect(headers![keyHeaderInstallationId], isNotEmpty);
+    });
 
-    test(
-      'omits X-Parse-Installation-Id when caller passes '
-      'sendInstallationId: false. The opt-out is forwarded by methods such '
-      'as ParseUser.signUp(doNotSendInstallationID: true) for callers that '
-      'cannot allow-list the header on their parse-server',
-      () async {
-        final Map<String, String>? headers = await client.exposedBuildHeaders(
-          ParseNetworkOptions(sendInstallationId: false),
-        );
+    test('omits X-Parse-Installation-Id when caller passes '
+        'sendInstallationId: false. The opt-out is forwarded by methods such '
+        'as ParseUser.signUp(doNotSendInstallationID: true) for callers that '
+        'cannot allow-list the header on their parse-server', () async {
+      final Map<String, String>? headers = await client.exposedBuildHeaders(
+        ParseNetworkOptions(sendInstallationId: false),
+      );
 
-        expect(
-          headers?[keyHeaderInstallationId],
-          isNull,
-          reason:
-              'sendInstallationId=false must suppress the header even when '
-              'an install ID is available',
-        );
-      },
-    );
+      expect(
+        headers?[keyHeaderInstallationId],
+        isNull,
+        reason:
+            'sendInstallationId=false must suppress the header even when '
+            'an install ID is available',
+      );
+    });
 
     test(
       'preserves a caller-supplied X-Parse-Installation-Id rather than '
@@ -120,20 +114,15 @@ void main() {
       },
     );
 
-    test(
-      'merges caller-supplied headers with the install ID. Custom headers '
-      'and the auto-attached install ID must coexist — neither side '
-      'overrides the other',
-      () async {
-        final Map<String, String>? headers = await client.exposedBuildHeaders(
-          ParseNetworkOptions(
-            headers: <String, String>{'X-Custom': 'value'},
-          ),
-        );
+    test('merges caller-supplied headers with the install ID. Custom headers '
+        'and the auto-attached install ID must coexist — neither side '
+        'overrides the other', () async {
+      final Map<String, String>? headers = await client.exposedBuildHeaders(
+        ParseNetworkOptions(headers: <String, String>{'X-Custom': 'value'}),
+      );
 
-        expect(headers!['X-Custom'], equals('value'));
-        expect(headers[keyHeaderInstallationId], isNotEmpty);
-      },
-    );
+      expect(headers!['X-Custom'], equals('value'));
+      expect(headers[keyHeaderInstallationId], isNotEmpty);
+    });
   });
 }

--- a/packages/dart/test/src/network/parse_dio_client_test.dart
+++ b/packages/dart/test/src/network/parse_dio_client_test.dart
@@ -16,9 +16,13 @@ class _HeaderCapturingAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     requests.add(Map<String, dynamic>.from(options.headers));
-    return ResponseBody.fromString('{}', 200, headers: <String, List<String>>{
-      Headers.contentTypeHeader: <String>[Headers.jsonContentType],
-    });
+    return ResponseBody.fromString(
+      '{}',
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
   }
 
   @override
@@ -89,22 +93,19 @@ void main() {
       parseDioClient.client.httpClientAdapter = adapter;
     });
 
-    test(
-      'headers returned by buildHeaders reach the outgoing request. This is '
-      'the wiring check between the inherited helper (covered in detail by '
-      'parse_client_test.dart) and dio\'s request pipeline — without it, a '
-      'refactor that bypassed buildHeaders would silently drop install IDs '
-      'on every request',
-      () async {
-        await parseDioClient.put('$serverUrl/classes/_User/abc', data: '{}');
+    test('headers returned by buildHeaders reach the outgoing request. This is '
+        'the wiring check between the inherited helper (covered in detail by '
+        'parse_client_test.dart) and dio\'s request pipeline — without it, a '
+        'refactor that bypassed buildHeaders would silently drop install IDs '
+        'on every request', () async {
+      await parseDioClient.put('$serverUrl/classes/_User/abc', data: '{}');
 
-        expect(adapter.requests, hasLength(1));
-        expect(
-          adapter.requests.first[keyHeaderInstallationId],
-          isNotEmpty,
-          reason: 'install ID added by buildHeaders must reach the wire',
-        );
-      },
-    );
+      expect(adapter.requests, hasLength(1));
+      expect(
+        adapter.requests.first[keyHeaderInstallationId],
+        isNotEmpty,
+        reason: 'install ID added by buildHeaders must reach the wire',
+      );
+    });
   });
 }

--- a/packages/dart/test/src/network/parse_dio_client_test.dart
+++ b/packages/dart/test/src/network/parse_dio_client_test.dart
@@ -4,6 +4,27 @@ import 'package:test/test.dart';
 
 import '../../test_utils.dart';
 
+/// Records the headers of every request made through it without performing
+/// the actual HTTP call. Returns an empty 200 OK so callers can `await`.
+class _HeaderCapturingAdapter implements HttpClientAdapter {
+  final List<Map<String, dynamic>> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(Map<String, dynamic>.from(options.headers));
+    return ResponseBody.fromString('{}', 200, headers: <String, List<String>>{
+      Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 void main() {
   setUpAll(() async {
     await initializeParse();
@@ -56,5 +77,34 @@ void main() {
       // assert
       expect(parseDioClient.additionalHeaders, isNull);
     });
+  });
+
+  group('ParseDioClient request pipeline integration', () {
+    late ParseDioClient parseDioClient;
+    late _HeaderCapturingAdapter adapter;
+
+    setUp(() async {
+      parseDioClient = ParseDioClient();
+      adapter = _HeaderCapturingAdapter();
+      parseDioClient.client.httpClientAdapter = adapter;
+    });
+
+    test(
+      'headers returned by buildHeaders reach the outgoing request. This is '
+      'the wiring check between the inherited helper (covered in detail by '
+      'parse_client_test.dart) and dio\'s request pipeline — without it, a '
+      'refactor that bypassed buildHeaders would silently drop install IDs '
+      'on every request',
+      () async {
+        await parseDioClient.put('$serverUrl/classes/_User/abc', data: '{}');
+
+        expect(adapter.requests, hasLength(1));
+        expect(
+          adapter.requests.first[keyHeaderInstallationId],
+          isNotEmpty,
+          reason: 'install ID added by buildHeaders must reach the wire',
+        );
+      },
+    );
   });
 }

--- a/packages/dart/test/src/network/parse_http_client_test.dart
+++ b/packages/dart/test/src/network/parse_http_client_test.dart
@@ -9,20 +9,20 @@ void main() {
     await initializeParse();
   });
 
-  group('ParseDioClient Tests', () {
+  group('ParseHTTPClient Tests', () {
     late ParseHTTPClient parseHTTPClient;
 
     setUp(() async {
       parseHTTPClient = ParseHTTPClient();
     });
 
-    test('should return an instance of Dio from dioClient', () {
+    test('should return an instance of http.BaseClient from client getter', () {
       // arrange
-      final dioClient = parseHTTPClient.client;
+      final httpClient = parseHTTPClient.client;
 
       // assert
-      expect(dioClient, isNotNull);
-      expect(dioClient, isA<http.BaseClient>());
+      expect(httpClient, isNotNull);
+      expect(httpClient, isA<http.BaseClient>());
     });
   });
 }

--- a/packages/dart/test/src/network/parse_query_test.mocks.dart
+++ b/packages/dart/test/src/network/parse_query_test.mocks.dart
@@ -209,4 +209,14 @@ class MockParseClient extends _i1.Mock implements _i2.ParseClient {
             ),
           )
           as _i3.Future<_i2.ParseNetworkByteResponse>);
+
+  @override
+  _i3.Future<Map<String, String>?> buildHeaders(
+    _i2.ParseNetworkOptions? options,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#buildHeaders, [options]),
+            returnValue: _i3.Future<Map<String, String>?>.value(),
+          )
+          as _i3.Future<Map<String, String>?>);
 }

--- a/packages/dart/test/src/objects/parse_object/parse_object_test.mocks.dart
+++ b/packages/dart/test/src/objects/parse_object/parse_object_test.mocks.dart
@@ -209,4 +209,14 @@ class MockParseClient extends _i1.Mock implements _i2.ParseClient {
             ),
           )
           as _i3.Future<_i2.ParseNetworkByteResponse>);
+
+  @override
+  _i3.Future<Map<String, String>?> buildHeaders(
+    _i2.ParseNetworkOptions? options,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#buildHeaders, [options]),
+            returnValue: _i3.Future<Map<String, String>?>.value(),
+          )
+          as _i3.Future<Map<String, String>?>);
 }

--- a/packages/dart/test/src/objects/parse_user/parse_user_anonymous_link_test.dart
+++ b/packages/dart/test/src/objects/parse_user/parse_user_anonymous_link_test.dart
@@ -25,9 +25,7 @@ void main() {
       client = MockParseClient();
     });
 
-    ParseUser anonymousUserWithObjectId({
-      Map<String, dynamic>? extraAuthData,
-    }) {
+    ParseUser anonymousUserWithObjectId({Map<String, dynamic>? extraAuthData}) {
       final ParseUser user = ParseUser(null, null, null, client: client);
       final Map<String, dynamic> authData = <String, dynamic>{
         'anonymous': <String, dynamic>{'id': anonymousId},
@@ -60,49 +58,82 @@ void main() {
       },
     );
 
-    test(
-      'after a successful save, the local authData no longer contains the '
-      'anonymous entry. this matches the post-cleanup server record without '
-      'requiring a follow-up GET — the PUT response from Parse Server omits '
-      'authData even after the beforeSave trigger strips the anonymous entry',
-      () async {
-        final ParseUser user = anonymousUserWithObjectId();
+    test('after a successful save(), the local authData no longer contains '
+        'the anonymous entry. the PUT response carries only the fields the '
+        'client wrote, so the post-save cleanup is what reconciles local '
+        'state with the server-side unlink', () async {
+      final ParseUser user = anonymousUserWithObjectId();
 
-        // Server response only carries the dirty fields it processed; no
-        // authData echoed back. This is the realistic Parse Server shape.
-        when(
-          client.put(
-            putPath,
-            options: anyNamed('options'),
-            data: anyNamed('data'),
-          ),
-        ).thenAnswer(
-          (_) async => ParseNetworkResponse(
-            statusCode: 200,
-            data: jsonEncode(<String, dynamic>{
-              keyVarUsername: 'alice@example.com',
-              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
-              keyVarSessionToken: 'r:newtoken',
-            }),
-          ),
-        );
+      when(
+        client.put(
+          putPath,
+          options: anyNamed('options'),
+          data: anyNamed('data'),
+        ),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: jsonEncode(<String, dynamic>{
+            keyVarUsername: 'alice@example.com',
+            keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            keyVarSessionToken: 'r:newtoken',
+          }),
+        ),
+      );
 
-        user.username = 'alice@example.com';
-        user.password = 'hunter2';
+      user.username = 'alice@example.com';
+      user.password = 'hunter2';
 
-        final ParseResponse response = await user.save();
+      final ParseResponse response = await user.save();
 
-        expect(response.success, isTrue);
-        final Map<String, dynamic>? cleaned = user.authData;
-        expect(
-          cleaned == null || !cleaned.containsKey('anonymous'),
-          isTrue,
-          reason:
-              'authData.anonymous should be removed locally after a '
-              'successful conversion save',
-        );
-      },
-    );
+      expect(response.success, isTrue);
+      final Map<String, dynamic>? cleaned = user.authData;
+      expect(
+        cleaned == null || !cleaned.containsKey('anonymous'),
+        isTrue,
+        reason:
+            'authData.anonymous should be removed locally after a '
+            'successful conversion save',
+      );
+    });
+
+    test('after a successful update(), the local authData no longer contains '
+        'the anonymous entry. update() and save() both run the post-save '
+        'cleanup, so each path needs independent coverage', () async {
+      final ParseUser user = anonymousUserWithObjectId();
+
+      when(
+        client.put(
+          putPath,
+          options: anyNamed('options'),
+          data: anyNamed('data'),
+        ),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: jsonEncode(<String, dynamic>{
+            keyVarUsername: 'alice@example.com',
+            keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            keyVarSessionToken: 'r:newtoken',
+          }),
+        ),
+      );
+
+      user.username = 'alice@example.com';
+      user.password = 'hunter2';
+
+      final ParseResponse response = await user.update();
+
+      expect(response.success, isTrue);
+      final Map<String, dynamic>? cleaned = user.authData;
+      expect(
+        cleaned == null || !cleaned.containsKey('anonymous'),
+        isTrue,
+        reason:
+            'authData.anonymous should be removed locally after a '
+            'successful conversion update',
+      );
+    });
 
     test(
       'the PUT body for an anonymous-conversion save carries '
@@ -184,30 +215,27 @@ void main() {
       },
     );
 
-    test(
-      'on a lazy (no objectId) anonymous user, setting username drops the '
-      'anonymous entry locally without leaving a null marker. unpersisted '
-      'users have nothing to unlink server-side, so no marker is needed',
-      () {
-        final ParseUser user = ParseUser(null, null, null, client: client);
-        user.fromJson(<String, dynamic>{
-          keyVarAuthData: <String, dynamic>{
-            'anonymous': <String, dynamic>{'id': anonymousId},
-          },
-        });
+    test('on a lazy (no objectId) anonymous user, setting username drops the '
+        'anonymous entry locally without leaving a null marker. unpersisted '
+        'users have nothing to unlink server-side, so no marker is needed', () {
+      final ParseUser user = ParseUser(null, null, null, client: client);
+      user.fromJson(<String, dynamic>{
+        keyVarAuthData: <String, dynamic>{
+          'anonymous': <String, dynamic>{'id': anonymousId},
+        },
+      });
 
-        user.username = 'alice@example.com';
+      user.username = 'alice@example.com';
 
-        final Map<String, dynamic>? cleaned = user.authData;
-        expect(
-          cleaned == null || !cleaned.containsKey('anonymous'),
-          isTrue,
-          reason:
-              'unpersisted anonymous user should drop the entry without '
-              'leaving a null marker',
-        );
-      },
-    );
+      final Map<String, dynamic>? cleaned = user.authData;
+      expect(
+        cleaned == null || !cleaned.containsKey('anonymous'),
+        isTrue,
+        reason:
+            'unpersisted anonymous user should drop the entry without '
+            'leaving a null marker',
+      );
+    });
   });
 
   group('ParseUser save() regression — non-anonymous users', () {

--- a/packages/dart/test/src/objects/parse_user/parse_user_anonymous_link_test.dart
+++ b/packages/dart/test/src/objects/parse_user/parse_user_anonymous_link_test.dart
@@ -1,0 +1,273 @@
+import 'dart:convert';
+
+import 'package:mockito/mockito.dart';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../../parse_query_test.mocks.dart';
+import '../../../test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('ParseUser anonymous → email/password conversion', () {
+    late MockParseClient client;
+
+    const String userObjectId = 'abc123XYZ';
+    const String anonymousId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    final String putPath = Uri.parse(
+      '$serverUrl$keyEndPointClasses$keyClassUser/$userObjectId',
+    ).toString();
+
+    setUp(() {
+      client = MockParseClient();
+    });
+
+    ParseUser anonymousUserWithObjectId({
+      Map<String, dynamic>? extraAuthData,
+    }) {
+      final ParseUser user = ParseUser(null, null, null, client: client);
+      final Map<String, dynamic> authData = <String, dynamic>{
+        'anonymous': <String, dynamic>{'id': anonymousId},
+      };
+      if (extraAuthData != null) {
+        authData.addAll(extraAuthData);
+      }
+      user.fromJson(<String, dynamic>{
+        keyVarObjectId: userObjectId,
+        keyVarSessionToken: 'r:abcdef0123456789',
+        keyVarAuthData: authData,
+        keyVarCreatedAt: '2026-04-28T12:00:00.000Z',
+        keyVarUpdatedAt: '2026-04-28T12:00:00.000Z',
+      });
+      return user;
+    }
+
+    test(
+      'setting username on a persisted anonymous user marks the anonymous '
+      'authData entry for unlinking by setting its value to null. the null '
+      'value is the unlink signal Parse Server interprets on the next save',
+      () {
+        final ParseUser user = anonymousUserWithObjectId();
+
+        user.username = 'alice@example.com';
+
+        expect(user.authData, isNotNull);
+        expect(user.authData!.containsKey('anonymous'), isTrue);
+        expect(user.authData!['anonymous'], isNull);
+      },
+    );
+
+    test(
+      'after a successful save, the local authData no longer contains the '
+      'anonymous entry. this matches the post-cleanup server record without '
+      'requiring a follow-up GET — the PUT response from Parse Server omits '
+      'authData even after the beforeSave trigger strips the anonymous entry',
+      () async {
+        final ParseUser user = anonymousUserWithObjectId();
+
+        // Server response only carries the dirty fields it processed; no
+        // authData echoed back. This is the realistic Parse Server shape.
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer(
+          (_) async => ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUsername: 'alice@example.com',
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+              keyVarSessionToken: 'r:newtoken',
+            }),
+          ),
+        );
+
+        user.username = 'alice@example.com';
+        user.password = 'hunter2';
+
+        final ParseResponse response = await user.save();
+
+        expect(response.success, isTrue);
+        final Map<String, dynamic>? cleaned = user.authData;
+        expect(
+          cleaned == null || !cleaned.containsKey('anonymous'),
+          isTrue,
+          reason:
+              'authData.anonymous should be removed locally after a '
+              'successful conversion save',
+        );
+      },
+    );
+
+    test(
+      'the PUT body for an anonymous-conversion save carries '
+      'authData.anonymous = null. this is the wire-level unlink signal that '
+      'lets Parse Server clean the server-side record on the same round-trip',
+      () async {
+        final ParseUser user = anonymousUserWithObjectId();
+
+        String? capturedBody;
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer((Invocation invocation) async {
+          capturedBody =
+              invocation.namedArguments[const Symbol('data')] as String?;
+          return ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            }),
+          );
+        });
+
+        user.username = 'alice@example.com';
+        user.password = 'hunter2';
+
+        await user.save();
+
+        expect(capturedBody, isNotNull);
+        final Map<String, dynamic> decoded =
+            jsonDecode(capturedBody!) as Map<String, dynamic>;
+        expect(decoded[keyVarAuthData], isA<Map>());
+        final Map<String, dynamic> sentAuthData =
+            (decoded[keyVarAuthData] as Map).cast<String, dynamic>();
+        expect(sentAuthData.containsKey('anonymous'), isTrue);
+        expect(sentAuthData['anonymous'], isNull);
+      },
+    );
+
+    test(
+      'non-anonymous authData entries (e.g. facebook, google) survive the '
+      'conversion. only the anonymous null marker is dropped on cleanup',
+      () async {
+        final ParseUser user = anonymousUserWithObjectId(
+          extraAuthData: <String, dynamic>{
+            'facebook': <String, dynamic>{
+              'id': 'fb-12345',
+              'access_token': 'tok',
+            },
+          },
+        );
+
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer(
+          (_) async => ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            }),
+          ),
+        );
+
+        user.username = 'alice@example.com';
+
+        await user.save();
+
+        expect(user.authData, isNotNull);
+        expect(user.authData!.containsKey('anonymous'), isFalse);
+        expect(user.authData!.containsKey('facebook'), isTrue);
+        expect(user.authData!['facebook'], isNotNull);
+      },
+    );
+
+    test(
+      'on a lazy (no objectId) anonymous user, setting username drops the '
+      'anonymous entry locally without leaving a null marker. unpersisted '
+      'users have nothing to unlink server-side, so no marker is needed',
+      () {
+        final ParseUser user = ParseUser(null, null, null, client: client);
+        user.fromJson(<String, dynamic>{
+          keyVarAuthData: <String, dynamic>{
+            'anonymous': <String, dynamic>{'id': anonymousId},
+          },
+        });
+
+        user.username = 'alice@example.com';
+
+        final Map<String, dynamic>? cleaned = user.authData;
+        expect(
+          cleaned == null || !cleaned.containsKey('anonymous'),
+          isTrue,
+          reason:
+              'unpersisted anonymous user should drop the entry without '
+              'leaving a null marker',
+        );
+      },
+    );
+  });
+
+  group('ParseUser save() regression — non-anonymous users', () {
+    late MockParseClient client;
+
+    const String userObjectId = 'reg123';
+    final String putPath = Uri.parse(
+      '$serverUrl$keyEndPointClasses$keyClassUser/$userObjectId',
+    ).toString();
+
+    setUp(() {
+      client = MockParseClient();
+    });
+
+    test(
+      'setting username on a non-anonymous user does not synthesize authData '
+      'into the request body. only the anonymous-conversion case should '
+      'inject the null marker',
+      () async {
+        final ParseUser user = ParseUser(null, null, null, client: client);
+        user.fromJson(<String, dynamic>{
+          keyVarObjectId: userObjectId,
+          keyVarSessionToken: 'r:xyz',
+          keyVarUsername: 'old@example.com',
+        });
+
+        String? capturedBody;
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer((Invocation invocation) async {
+          capturedBody =
+              invocation.namedArguments[const Symbol('data')] as String?;
+          return ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            }),
+          );
+        });
+
+        user.username = 'new@example.com';
+
+        final ParseResponse response = await user.save();
+
+        expect(response.success, isTrue);
+        expect(capturedBody, isNotNull);
+        final Map<String, dynamic> decoded =
+            jsonDecode(capturedBody!) as Map<String, dynamic>;
+        expect(
+          decoded.containsKey(keyVarAuthData),
+          isFalse,
+          reason:
+              'a regular username update on a non-anonymous user should not '
+              'synthesize authData in the request body',
+        );
+      },
+    );
+  });
+}

--- a/packages/dart/test/src/objects/parse_user/parse_user_session_token_test.dart
+++ b/packages/dart/test/src/objects/parse_user/parse_user_session_token_test.dart
@@ -24,122 +24,113 @@ void main() {
       client = MockParseClient();
     });
 
-    test(
-      'when a save() response carries a sessionToken different from the '
-      'one sent, the SDK installs it as the global session token. Parse '
-      'Server mints a fresh session when password is set on an existing '
-      '_User; the prior session is destroyed server-side, so the global '
-      'session must be updated or subsequent requests fail with '
-      'invalidSessionToken',
-      () async {
-        ParseCoreData().setSessionId('r:priorSession');
+    test('when a save() response carries a sessionToken different from the '
+        'one sent, the SDK installs it as the global session token. Parse '
+        'Server mints a fresh session when password is set on an existing '
+        '_User; the prior session is destroyed server-side, so the global '
+        'session must be updated or subsequent requests fail with '
+        'invalidSessionToken', () async {
+      ParseCoreData().setSessionId('r:priorSession');
 
-        final ParseUser user = ParseUser(null, null, null, client: client);
-        user.fromJson(<String, dynamic>{
-          keyVarObjectId: userObjectId,
-          keyVarSessionToken: 'r:priorSession',
-          keyVarUsername: 'alice@example.com',
-        });
+      final ParseUser user = ParseUser(null, null, null, client: client);
+      user.fromJson(<String, dynamic>{
+        keyVarObjectId: userObjectId,
+        keyVarSessionToken: 'r:priorSession',
+        keyVarUsername: 'alice@example.com',
+      });
 
-        when(
-          client.put(
-            putPath,
-            options: anyNamed('options'),
-            data: anyNamed('data'),
-          ),
-        ).thenAnswer(
-          (_) async => ParseNetworkResponse(
-            statusCode: 200,
-            data: jsonEncode(<String, dynamic>{
-              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
-              keyVarSessionToken: 'r:freshSession',
-            }),
-          ),
-        );
+      when(
+        client.put(
+          putPath,
+          options: anyNamed('options'),
+          data: anyNamed('data'),
+        ),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: jsonEncode(<String, dynamic>{
+            keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            keyVarSessionToken: 'r:freshSession',
+          }),
+        ),
+      );
 
-        user.password = 'hunter2';
+      user.password = 'hunter2';
 
-        final ParseResponse response = await user.save();
+      final ParseResponse response = await user.save();
 
-        expect(response.success, isTrue);
-        expect(ParseCoreData().sessionId, equals('r:freshSession'));
-      },
-    );
+      expect(response.success, isTrue);
+      expect(ParseCoreData().sessionId, equals('r:freshSession'));
+    });
 
-    test(
-      'when a save() response does NOT carry a sessionToken, the global '
-      'session is left untouched. the previously-cached local sessionToken '
-      'on the user object must not be re-promoted to global state',
-      () async {
-        ParseCoreData().setSessionId('r:stableSession');
+    test('when a save() response does NOT carry a sessionToken, the global '
+        'session is left untouched. the previously-cached local sessionToken '
+        'on the user object must not be re-promoted to global state', () async {
+      ParseCoreData().setSessionId('r:stableSession');
 
-        final ParseUser user = ParseUser(null, null, null, client: client);
-        user.fromJson(<String, dynamic>{
-          keyVarObjectId: userObjectId,
-          keyVarSessionToken: 'r:stableSession',
-          keyVarUsername: 'alice@example.com',
-        });
+      final ParseUser user = ParseUser(null, null, null, client: client);
+      user.fromJson(<String, dynamic>{
+        keyVarObjectId: userObjectId,
+        keyVarSessionToken: 'r:stableSession',
+        keyVarUsername: 'alice@example.com',
+      });
 
-        when(
-          client.put(
-            putPath,
-            options: anyNamed('options'),
-            data: anyNamed('data'),
-          ),
-        ).thenAnswer(
-          (_) async => ParseNetworkResponse(
-            statusCode: 200,
-            data: jsonEncode(<String, dynamic>{
-              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
-            }),
-          ),
-        );
+      when(
+        client.put(
+          putPath,
+          options: anyNamed('options'),
+          data: anyNamed('data'),
+        ),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: jsonEncode(<String, dynamic>{
+            keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+          }),
+        ),
+      );
 
-        user.set<String>('localeIdentifier', 'en-US');
+      user.set<String>('localeIdentifier', 'en-US');
 
-        await user.save();
+      await user.save();
 
-        expect(ParseCoreData().sessionId, equals('r:stableSession'));
-      },
-    );
+      expect(ParseCoreData().sessionId, equals('r:stableSession'));
+    });
 
-    test(
-      'update() adopts a new sessionToken from the response. save() and '
-      'update() are independent entry points, both need to install the '
-      'token to keep the active session in sync with the server',
-      () async {
-        ParseCoreData().setSessionId('r:priorSession');
+    test('update() adopts a new sessionToken from the response. save() and '
+        'update() are independent entry points, both need to install the '
+        'token to keep the active session in sync with the server', () async {
+      ParseCoreData().setSessionId('r:priorSession');
 
-        final ParseUser user = ParseUser(null, null, null, client: client);
-        user.fromJson(<String, dynamic>{
-          keyVarObjectId: userObjectId,
-          keyVarSessionToken: 'r:priorSession',
-          keyVarUsername: 'alice@example.com',
-        });
+      final ParseUser user = ParseUser(null, null, null, client: client);
+      user.fromJson(<String, dynamic>{
+        keyVarObjectId: userObjectId,
+        keyVarSessionToken: 'r:priorSession',
+        keyVarUsername: 'alice@example.com',
+      });
 
-        when(
-          client.put(
-            putPath,
-            options: anyNamed('options'),
-            data: anyNamed('data'),
-          ),
-        ).thenAnswer(
-          (_) async => ParseNetworkResponse(
-            statusCode: 200,
-            data: jsonEncode(<String, dynamic>{
-              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
-              keyVarSessionToken: 'r:freshSession',
-            }),
-          ),
-        );
+      when(
+        client.put(
+          putPath,
+          options: anyNamed('options'),
+          data: anyNamed('data'),
+        ),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: jsonEncode(<String, dynamic>{
+            keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            keyVarSessionToken: 'r:freshSession',
+          }),
+        ),
+      );
 
-        user.password = 'hunter2';
+      user.password = 'hunter2';
 
-        final ParseResponse response = await user.update();
+      final ParseResponse response = await user.update();
 
-        expect(response.success, isTrue);
-        expect(ParseCoreData().sessionId, equals('r:freshSession'));
-      },
-    );
+      expect(response.success, isTrue);
+      expect(ParseCoreData().sessionId, equals('r:freshSession'));
+    });
   });
 }

--- a/packages/dart/test/src/objects/parse_user/parse_user_session_token_test.dart
+++ b/packages/dart/test/src/objects/parse_user/parse_user_session_token_test.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:mockito/mockito.dart';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../../parse_query_test.mocks.dart';
+import '../../../test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('ParseUser save()/update() — sessionToken adoption from response', () {
+    late MockParseClient client;
+
+    const String userObjectId = 'sess123';
+    final String putPath = Uri.parse(
+      '$serverUrl$keyEndPointClasses$keyClassUser/$userObjectId',
+    ).toString();
+
+    setUp(() {
+      client = MockParseClient();
+    });
+
+    test(
+      'when a save() response carries a sessionToken different from the '
+      'one sent, the SDK installs it as the global session token. Parse '
+      'Server mints a fresh session when password is set on an existing '
+      '_User; the prior session is destroyed server-side, so the global '
+      'session must be updated or subsequent requests fail with '
+      'invalidSessionToken',
+      () async {
+        ParseCoreData().setSessionId('r:priorSession');
+
+        final ParseUser user = ParseUser(null, null, null, client: client);
+        user.fromJson(<String, dynamic>{
+          keyVarObjectId: userObjectId,
+          keyVarSessionToken: 'r:priorSession',
+          keyVarUsername: 'alice@example.com',
+        });
+
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer(
+          (_) async => ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+              keyVarSessionToken: 'r:freshSession',
+            }),
+          ),
+        );
+
+        user.password = 'hunter2';
+
+        final ParseResponse response = await user.save();
+
+        expect(response.success, isTrue);
+        expect(ParseCoreData().sessionId, equals('r:freshSession'));
+      },
+    );
+
+    test(
+      'when a save() response does NOT carry a sessionToken, the global '
+      'session is left untouched. the previously-cached local sessionToken '
+      'on the user object must not be re-promoted to global state',
+      () async {
+        ParseCoreData().setSessionId('r:stableSession');
+
+        final ParseUser user = ParseUser(null, null, null, client: client);
+        user.fromJson(<String, dynamic>{
+          keyVarObjectId: userObjectId,
+          keyVarSessionToken: 'r:stableSession',
+          keyVarUsername: 'alice@example.com',
+        });
+
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer(
+          (_) async => ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+            }),
+          ),
+        );
+
+        user.set<String>('localeIdentifier', 'en-US');
+
+        await user.save();
+
+        expect(ParseCoreData().sessionId, equals('r:stableSession'));
+      },
+    );
+
+    test(
+      'update() adopts a new sessionToken from the response. save() and '
+      'update() are independent entry points, both need to install the '
+      'token to keep the active session in sync with the server',
+      () async {
+        ParseCoreData().setSessionId('r:priorSession');
+
+        final ParseUser user = ParseUser(null, null, null, client: client);
+        user.fromJson(<String, dynamic>{
+          keyVarObjectId: userObjectId,
+          keyVarSessionToken: 'r:priorSession',
+          keyVarUsername: 'alice@example.com',
+        });
+
+        when(
+          client.put(
+            putPath,
+            options: anyNamed('options'),
+            data: anyNamed('data'),
+          ),
+        ).thenAnswer(
+          (_) async => ParseNetworkResponse(
+            statusCode: 200,
+            data: jsonEncode(<String, dynamic>{
+              keyVarUpdatedAt: '2026-04-28T12:00:01.000Z',
+              keyVarSessionToken: 'r:freshSession',
+            }),
+          ),
+        );
+
+        user.password = 'hunter2';
+
+        final ParseResponse response = await user.update();
+
+        expect(response.success, isTrue);
+        expect(ParseCoreData().sessionId, equals('r:freshSession'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Issue

No existing issue; problems described below.

## Approach

The Dart SDK's anonymous-to-password user conversion
(`user.username = email; user.password = pw; user.save()` after
`loginAnonymous()`) has three independent gaps vs the iOS SDK. All
three surfaced during empirical testing in a production-mirror setup
as causes of `invalidSessionToken` rejections or orphan `_Session`
row accumulation. This PR ports iOS's behavior into the Dart SDK
across three logically-distinct commits.

### Fix 1 — Reconcile local `authData` on conversion

When a persisted anonymous user has its `username` set and is saved,
`parseUser.save()` issues a `PUT /classes/_User/:objectId` carrying
only the dirty fields. The Dart SDK treated this as a generic
property update — it neither emitted an `authData` unlink signal in
the request body nor cleaned up the local cache after the save.

The iOS Parse SDK handles this via two helpers in `PFUser.m`:

1. **`stripAnonymity`** (`PFUser.m:593-607`): the `username` setter
   writes `authData[anonymous] = NSNull` into the local user. The
   PUT body re-injects the map, so the request carries
   `authData: { anonymous: null }` — Parse Server's documented
   unlink signal.
2. **`cleanUpAuthData`** (`PFUser.m:300-313`): after a successful
   save, the local `authData` has any null entries stripped.

Ported to `ParseUser` as two private helpers:

- `_stripAnonymity()` invoked from the `username` setter. On a
  persisted user it sets `authData['anonymous'] = null` locally; on
  a lazy user (no `objectId`) it removes the entry outright.
- `_cleanUpAuthData()` invoked from `save()` and `update()` between
  the response merge and `_onResponseSuccess()`.

A dartdoc paragraph was added to `loginAnonymous` documenting the
conversion path.

### Fix 2 — Adopt `sessionToken` from the save/update response

Parse Server mints a fresh `_Session` row when `password` is set on
an existing `_User` (with `revokeSessionOnPasswordReset = true`, the
current default in parse-server 9.x). The new `sessionToken` is
embedded in the save response. Without adopting it, the global
session in `ParseCoreData` keeps pointing at the prior session —
which the server just destroyed — and every subsequent request
fails with `invalidSessionToken` until the next login.

This mirrors `PFUser._mergeFromServerWithResult` on iOS, which reads
`PFUserSessionTokenRESTKey` out of the response and installs it.

Implemented as `_adoptResponseSessionTokenIfChanged(String?)`
invoked from `save()` and `update()`. The helper is a no-op when
the response carries no `sessionToken` (e.g. a plain field update),
preserving the existing behavior for non-auth saves.

### Fix 3 — Send `X-Parse-Installation-Id` on all HTTP requests

iOS's `PFURLSessionCommandRunner` attaches the install ID header to
every outgoing request
(`PFCommandURLRequestConstructor.m:_getURLRequestHeadersAsyncForCommand:`).
The Dart SDK previously built the header inline only in the four
user-creation methods (`signUp`, `login`, `loginAnonymous`,
`loginWith`). Every other call — including `PUT` save on an
existing user — went out without it.

Without the install ID on writes, parse-server cannot bind the
`_Session` row it mints during an authData/password change to the
device's installation, and `destroyDuplicatedSessions` skips
cleanup of prior sessions on the same install. Empirically this
leaves one orphan `_Session` row per anonymous-to-password link.

Changes:

- Added `sendInstallationId: bool?` to `ParseNetworkOptions`
  (null/true → attach, false → suppress).
- Hoisted a shared `buildHeaders` helper onto the abstract
  `ParseClient` (`@protected`); both `ParseHTTPClient` and
  `ParseDioClient` inherit and route through it.
- `ParseUser.signUp/login/loginAnonymous/_loginWith` drop their
  inline `_getInstallationId()` and pass
  `sendInstallationId: !doNotSendInstallationID` through options —
  the user-facing opt-out parameter continues to work.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)

## Behavior change disclosure

1. **Wire — anonymous conversion save**: when `objectId` is set
   and `authData` contains an `anonymous` entry, setting `username`
   and saving now produces a PUT body that includes
   `authData: { anonymous: null }`. Previously no `authData` field
   was sent for that save.
2. **Local cache — anonymous conversion**: setting `username` on
   an anonymous-with-`objectId` `ParseUser` now mutates the local
   `authData` map. After a successful save, the `anonymous` entry
   is removed entirely.
3. **Session token — save/update response**: when a `_User`
   save/update response carries a `sessionToken` field (i.e.
   parse-server minted a new session), the SDK installs it as the
   active session via `ParseCoreData().setSessionId(...)`.
   Previously the new token was merged into the local user object
   but the global session continued pointing at the prior token.
4. **Request headers — all HTTP requests**: every outgoing
   request now carries `X-Parse-Installation-Id` by default.
   Previously only `signUp`, `login`, `loginAnonymous`, and
   `loginWith` set it. Opt-out is preserved via
   `ParseNetworkOptions(sendInstallationId: false)` and the
   existing `doNotSendInstallationID` parameter on user methods.

The commit prefixes mix `fix:` and `feat:`. The PR is labeled
`feat:` overall — the install-ID change is a feature-level default
change, even with opt-out preserved.

If maintainers prefer to split commits `83244367` and `5b2cd09e`
into separate PRs, they are independent of each other and of the
original three commits and can be cherry-picked onto clean branches.

## Documentation follow-up (out of scope for this PR)

This PR adds a dartdoc paragraph to `loginAnonymous` covering the
conversion pattern. The companion user guide at
https://docs.parseplatform.org/dart/guide/ (separate repo) has no
section equivalent to the iOS guide's "Linking Anonymous Users".
Mirroring that section into the Dart guide is a natural follow-up
once this PR lands.

## Tests

Added to `packages/dart/test/src/`:

- `objects/parse_user/parse_user_anonymous_link_test.dart` — 6
  tests covering Fix 1 (authData reconciliation behavior).
- `objects/parse_user/parse_user_session_token_test.dart` (new) —
  3 tests covering Fix 2 (sessionToken adoption from save/update
  response).
- `network/parse_client_test.dart` (new) — 4 unit tests covering
  Fix 3's `buildHeaders` helper (default attach, opt-out via
  `sendInstallationId`, preserve caller-supplied header, merge with
  custom headers).
- `network/parse_dio_client_test.dart` — 1 new integration test
  verifying `buildHeaders` output reaches dio's request pipeline
  via a custom `HttpClientAdapter`.
- `network/parse_http_client_test.dart` — copy-pasted
  "ParseDioClient" group label corrected to "ParseHTTPClient".

Total: 14 new tests across 4 test files. All 221 tests in
`packages/dart/test/` pass.
