### PR TITLE
fix: `ParseInstallation` saves `timeZone` field as empty string

### DIFF
--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -95,20 +95,37 @@ class ParseInstallation extends ParseObject {
 
   String _getNameLocalTimeZone() {
     tz.initializeTimeZones();
-    var locations = tz.timeZoneDatabase.locations;
 
-    Duration offset = DateTime.now().timeZoneOffset;
-    String name = "";
+    // Capture once to avoid a DST-transition race between the two reads.
+    final DateTime now = DateTime.now();
 
-    locations.forEach((key, value) {
-      for (var element in value.zones) {
-        if (element.offset == offset) {
-          name = value.name;
-          break;
-        }
+    // Prefer the OS-reported zone name when it's a valid IANA location
+    // (e.g. "America/New_York" on macOS/Linux/iOS/Android). Avoids the
+    // ambiguity of matching by offset, where many zones share an offset.
+    final String systemName = now.timeZoneName;
+    if (tz.timeZoneDatabase.locations.containsKey(systemName)) {
+      return systemName;
+    }
+
+    // Fall back to a location whose *current* zone matches the local
+    // offset. The previous implementation scanned every historical zone
+    // (LMT, pre-DST, etc.) and compared a Duration against an int offset,
+    // which on timezone <0.11.0 is always false and produced "".
+    final int localOffsetMs = now.timeZoneOffset.inMilliseconds;
+    for (final location in tz.timeZoneDatabase.locations.values) {
+      final dynamic zoneOffset = location.currentTimeZone.offset;
+      final int zoneOffsetMs = zoneOffset is Duration
+          ? zoneOffset.inMilliseconds
+          : zoneOffset as int;
+      if (zoneOffsetMs == localOffsetMs) {
+        return location.name;
       }
-    });
-    return name;
+    }
+
+    // Last resort: return whatever the OS gave us rather than "".
+    // Note: on Windows/Web this may be a non-IANA name (e.g.
+    // "Pacific Standard Time" or "EDT"), but it's still better than "".
+    return systemName;
   }
 
   @override

--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -84,8 +84,26 @@ class ParseInstallation extends ParseObject {
     //Locale
     set<String?>(keyLocaleIdentifier, ParseCoreData().locale);
 
-    //Timezone
-    set<String>(keyTimeZone, _getNameLocalTimeZone());
+    //Timezone — don't overwrite a value the caller already set. The pure-Dart
+    //offset-match here picks the first IANA zone with the local offset, which
+    //is alphabetical (e.g. "America/Anguilla" for UTC-4 instead of
+    //"America/New_York"). Apps that need a real IANA name (via a Flutter
+    //plugin like flutter_timezone, or a Kotlin/Swift channel) should set
+    //`timeZone` on the installation before calling save(); the SDK will only
+    //fill it in when nothing is set.
+    //
+    //First-launch caveat: _createInstallation() runs this method and then
+    //persists the full installation JSON to the local store before any
+    //caller code runs. That means the offset-matched fallback IS written to
+    //disk on first launch. If the app crashes before the caller's
+    //set+save() runs, the next launch reads the fallback from storage, the
+    //gate sees it as "existing", and the SDK won't auto-correct. The
+    //caller's set+save self-heals as soon as it runs. Apps that resolve a
+    //real IANA name should do so early in startup.
+    final String? existingTimeZone = super.get<String>(keyTimeZone);
+    if (existingTimeZone == null || existingTimeZone.isEmpty) {
+      set<String>(keyTimeZone, _getNameLocalTimeZone());
+    }
 
     //App info
     set<String?>(keyAppName, ParseCoreData().appName);

--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -131,14 +131,30 @@ class ParseInstallation extends ParseObject {
     }
 
     // Fall back to a location whose *current* zone matches the local
-    // offset. The previous implementation scanned every historical zone
+    // offset, but only if exactly one IANA zone matches. Many zones share
+    // an offset at any instant (e.g. America/Los_Angeles, America/Vancouver,
+    // America/Tijuana), so returning the first match would arbitrarily pick
+    // a wrong location. Returning the OS string instead is non-IANA but at
+    // least not a fabricated guess.
+    //
+    // The previous implementation also scanned every historical zone
     // (LMT, pre-DST, etc.) and compared a Duration against an int offset,
     // which on timezone <0.11.0 is always false and produced "".
     final int localOffsetMs = now.timeZoneOffset.inMilliseconds;
+    String? offsetMatch;
     for (final location in tz.timeZoneDatabase.locations.values) {
-      if (_zoneOffsetMs(location.currentTimeZone.offset) == localOffsetMs) {
-        return location.name;
+      if (_zoneOffsetMs(location.currentTimeZone.offset) != localOffsetMs) {
+        continue;
       }
+      if (offsetMatch != null) {
+        // Ambiguous: multiple zones share this offset. Don't guess.
+        offsetMatch = null;
+        break;
+      }
+      offsetMatch = location.name;
+    }
+    if (offsetMatch != null) {
+      return offsetMatch;
     }
 
     // Last resort: return whatever the OS gave us rather than "".

--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -22,6 +22,7 @@ class ParseInstallation extends ParseObject {
     keyParseVersion,
   ];
   static String? _currentInstallationId;
+  static bool _timeZonesInitialized = false;
 
   //Getters/setters
   Map<String, dynamic> get acl => super.get<Map<String, dynamic>>(
@@ -94,7 +95,11 @@ class ParseInstallation extends ParseObject {
   }
 
   String _getNameLocalTimeZone() {
-    tz.initializeTimeZones();
+    // The timezone database is large; initialize it at most once per process.
+    if (!_timeZonesInitialized) {
+      tz.initializeTimeZones();
+      _timeZonesInitialized = true;
+    }
 
     // Capture once to avoid a DST-transition race between the two reads.
     final DateTime now = DateTime.now();
@@ -113,11 +118,7 @@ class ParseInstallation extends ParseObject {
     // which on timezone <0.11.0 is always false and produced "".
     final int localOffsetMs = now.timeZoneOffset.inMilliseconds;
     for (final location in tz.timeZoneDatabase.locations.values) {
-      final dynamic zoneOffset = location.currentTimeZone.offset;
-      final int zoneOffsetMs = zoneOffset is Duration
-          ? zoneOffset.inMilliseconds
-          : zoneOffset as int;
-      if (zoneOffsetMs == localOffsetMs) {
+      if (_zoneOffsetMs(location.currentTimeZone.offset) == localOffsetMs) {
         return location.name;
       }
     }
@@ -126,6 +127,14 @@ class ParseInstallation extends ParseObject {
     // Note: on Windows/Web this may be a non-IANA name (e.g.
     // "Pacific Standard Time" or "EDT"), but it's still better than "".
     return systemName;
+  }
+
+  // The `timezone` package returns `TimeZone.offset` as `int` (milliseconds)
+  // on <0.11.0 and as `Duration` on >=0.11.0. Normalize to milliseconds so
+  // the same comparison works across the full supported version range.
+  static int _zoneOffsetMs(dynamic offset) {
+    if (offset is Duration) return offset.inMilliseconds;
+    return offset as int;
   }
 
   @override

--- a/packages/dart/test/parse_installation_test.dart
+++ b/packages/dart/test/parse_installation_test.dart
@@ -16,6 +16,16 @@ Future<void> _initParse() => Parse().initialize(
 void main() {
   setUpAll(() async {
     await _initParse();
+    // Initialize the timezone database once for the whole suite; it loads a
+    // large dataset and only needs to happen once per process.
+    tz.initializeTimeZones();
+  });
+
+  // Each test re-derives the installation's timeZone from `DateTime.now()`, so
+  // it must not see a stale installation persisted by a previous test (which
+  // could differ across a DST boundary).
+  setUp(() async {
+    await ParseCoreData().getStore().remove(keyParseStoreInstallation);
   });
 
   test('installation has a timeZone field', () async {
@@ -40,12 +50,12 @@ void main() {
 
   test('installation timeZone is an IANA name or the OS-reported name',
       () async {
-    tz.initializeTimeZones();
+    final now = DateTime.now();
     final installation = await ParseInstallation.currentInstallation();
     final tzValue = installation.get<String>(keyTimeZone)!;
 
     final bool isIana = tz.timeZoneDatabase.locations.containsKey(tzValue);
-    final bool matchesSystem = tzValue == DateTime.now().timeZoneName;
+    final bool matchesSystem = tzValue == now.timeZoneName;
 
     expect(
       isIana || matchesSystem,
@@ -58,7 +68,8 @@ void main() {
 
   test('when timeZone is matched via offset, its offset equals the local offset',
       () async {
-    tz.initializeTimeZones();
+    // Capture once so a DST transition between reads can't make this flake.
+    final now = DateTime.now();
     final installation = await ParseInstallation.currentInstallation();
     final tzValue = installation.get<String>(keyTimeZone)!;
 
@@ -73,6 +84,6 @@ void main() {
         ? zoneOffset.inMilliseconds
         : zoneOffset as int;
 
-    expect(zoneOffsetMs, equals(DateTime.now().timeZoneOffset.inMilliseconds));
+    expect(zoneOffsetMs, equals(now.timeZoneOffset.inMilliseconds));
   });
 }

--- a/packages/dart/test/parse_installation_test.dart
+++ b/packages/dart/test/parse_installation_test.dart
@@ -1,30 +1,78 @@
 import 'package:parse_server_sdk/parse_server_sdk.dart';
 import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+Future<void> _initParse() => Parse().initialize(
+  'appId',
+  'https://example.com',
+  debug: true,
+  fileDirectory: 'someDirectory',
+  appName: 'appName',
+  appPackageName: 'somePackageName',
+  appVersion: 'someAppVersion',
+);
 
 void main() {
-  test('should return true for exist TimeZone.', () async {
-    // arrange
-    await Parse().initialize(
-      'appId',
-      'https://example.com',
-      debug: true,
-      // to prevent automatic detection
-      fileDirectory: 'someDirectory',
-      // to prevent automatic detection
-      appName: 'appName',
-      // to prevent automatic detection
-      appPackageName: 'somePackageName',
-      // to prevent automatic detection
-      appVersion: 'someAppVersion',
+  setUpAll(() async {
+    await _initParse();
+  });
+
+  test('installation has a timeZone field', () async {
+    final installation = await ParseInstallation.currentInstallation();
+    expect(installation.containsKey(keyTimeZone), isTrue);
+  });
+
+  // Regression: the SDK previously compared `int == Duration` when matching
+  // offsets against the timezone database. On timezone <0.11.0 that's always
+  // false, so the timeZone field was persisted as "". See
+  // _getNameLocalTimeZone() in parse_installation.dart.
+  test('installation timeZone is not empty', () async {
+    final installation = await ParseInstallation.currentInstallation();
+    final tzValue = installation.get<String>(keyTimeZone);
+    expect(tzValue, isNotNull);
+    expect(
+      tzValue,
+      isNotEmpty,
+      reason: 'Regression: timeZone was being stored as "".',
     );
+  });
 
-    // act
-    final ParseInstallation installation =
-        await ParseInstallation.currentInstallation();
+  test('installation timeZone is an IANA name or the OS-reported name',
+      () async {
+    tz.initializeTimeZones();
+    final installation = await ParseInstallation.currentInstallation();
+    final tzValue = installation.get<String>(keyTimeZone)!;
 
-    dynamic actualHasTimeZoneResult = installation.containsKey(keyTimeZone);
+    final bool isIana = tz.timeZoneDatabase.locations.containsKey(tzValue);
+    final bool matchesSystem = tzValue == DateTime.now().timeZoneName;
 
-    // assert
-    expect(actualHasTimeZoneResult, true);
+    expect(
+      isIana || matchesSystem,
+      isTrue,
+      reason:
+          'timeZone "$tzValue" should be an IANA zone or the OS-reported '
+          'name (fallback for Windows/Web).',
+    );
+  });
+
+  test('when timeZone is matched via offset, its offset equals the local offset',
+      () async {
+    tz.initializeTimeZones();
+    final installation = await ParseInstallation.currentInstallation();
+    final tzValue = installation.get<String>(keyTimeZone)!;
+
+    final location = tz.timeZoneDatabase.locations[tzValue];
+    if (location == null) {
+      // OS-reported, non-IANA fallback (Windows/Web). Nothing to verify.
+      return;
+    }
+
+    final dynamic zoneOffset = location.currentTimeZone.offset;
+    final int zoneOffsetMs = zoneOffset is Duration
+        ? zoneOffset.inMilliseconds
+        : zoneOffset as int;
+
+    expect(zoneOffsetMs, equals(DateTime.now().timeZoneOffset.inMilliseconds));
   });
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-Flutter/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-Flutter/blob/master/LICENSE).

## Issue

N/A — bug surfaced during local testing; no existing issue.

## Approach

`ParseInstallation._getNameLocalTimeZone()` returned `""` instead of an IANA timezone name (e.g. `America/New_York`), so installations were persisted with an empty `timeZone` field. This affects any server-side logic that targets users by locale, including push scheduling.

**Root cause:**
- The method compared `DateTime.now().timeZoneOffset` (a `Duration`) against `TimeZone.offset` from the `timezone` package. On `timezone <0.11.0` that field is an `int` (ms), so the equality check is always false and `name` stayed `""`. On `timezone >=0.11.0` both sides are `Duration`, but the loop scanned every *historical* zone for each location (LMT, pre-DST, etc.) and the outer `forEach` never broke out, so whichever location came last in map iteration won.

**Fix:**
- Capture `DateTime.now()` once to avoid a DST-transition race between the two reads.
- Prefer `DateTime.now().timeZoneName` when it's a valid IANA location key (macOS, Linux, iOS, Android typically report IANA names directly).
- Fall back to matching `location.currentTimeZone` (the current zone, not the full historical list) against the local offset. Handles both `int` and `Duration` offset shapes so the SDK stays compatible across the full `timezone: ">=0.9.4 <0.12.0"` constraint.
- Last resort returns the OS-reported name instead of `""`. On Windows/Web this may be non-IANA (`"Pacific Standard Time"`, `"EDT"`), but it's strictly better than empty.

**Tests:**
Expanded `parse_installation_test.dart` from one weak `containsKey` assertion (which passed even with the `""` bug) to four cases:
- `timeZone` field exists
- regression: `timeZone` is non-empty
- `timeZone` is either an IANA name or the OS-reported fallback
- when IANA-resolved, its current offset equals the system offset

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve caller-provided installation timeZone instead of overwriting it.
  * Improve timezone detection and initialize timezone data only once to avoid DST-related inconsistencies.
  * Prefer a valid IANA zone when available; otherwise fall back to the OS-reported timezone name.
  * Ensure stored timezone is non-empty and matches the system offset for consistent cross-environment reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-SDK-Flutter/pull/1141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->