### PR TITLE
fix: UnSubscribe removes entry from map regardless of socket state + add removeSubscriptions, clearAllSubscriptions and resetInstance utilities

### DIFF
--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -210,8 +210,19 @@ class LiveQueryClient {
     return parse_web_socket.WebSocket.connecting;
   }
 
+  /// Removes specific subscriptions from the map by requestId.
+/// Use this instead of clearAllSubscriptions() when other subscriptions
+/// (banners, notifications) must stay alive.
+void removeSubscriptions(List<Subscription> subs) {
+  for (final sub in subs) {
+    sub._enabled = false;
+    _requestSubscription.remove(sub.requestId);
+  }
+}
+
   /// Removes all subscriptions from the internal map.
 /// Call before disconnect when leaving a live room.
+  
 void clearAllSubscriptions() {
   _requestSubscription.values.toList().forEach((sub) {
     sub._enabled = false;

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -239,6 +239,11 @@ static Future<void> resetInstance() async {
     try {
       await existing.disconnect(userInitialized: false);
     } catch (_) {}
+    // Close the stream controller so asBroadcastStream() 
+    // doesn't throw on the next _internal() construction
+    try {
+      await existing._clientEventStreamController.close();
+    } catch (_) {}
   }
   _instance = null;
   _requestIdCount = 1;

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -201,6 +201,11 @@ class LiveQueryClient {
     await _connect(userInitialized: userInitialized);
     await _connectLiveQuery();
   }
+  void _safeAddEvent(LiveQueryClientEvent event) {
+  if (!_clientEventStreamController.isClosed) {
+    _clientEventStreamController.sink.add(event);
+  }
+}
 
   int readyState() {
     parse_web_socket.WebSocket? webSocket = _webSocket;
@@ -234,19 +239,23 @@ void clearAllSubscriptions() {
 /// Use userInitialized: false so reconnect still works after reset.
 static Future<void> resetInstance() async {
   final existing = _instance;
+  _instance = null;      // ← null first so new LiveQuery() calls don't
+  _requestIdCount = 1;   //   reuse the dying instance
+
   if (existing != null) {
     existing.clearAllSubscriptions();
     try {
       await existing.disconnect(userInitialized: false);
     } catch (_) {}
-    // Close the stream controller so asBroadcastStream() 
-    // doesn't throw on the next _internal() construction
+
+    // Wait for any in-flight socket callbacks (onDone etc.) to fire
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    // Close the stream controller last
     try {
       await existing._clientEventStreamController.close();
     } catch (_) {}
   }
-  _instance = null;
-  _requestIdCount = 1;
 }
   Future<dynamic> disconnect({bool userInitialized = false}) async {
     parse_web_socket.WebSocket? webSocket = _webSocket;
@@ -271,9 +280,7 @@ static Future<void> resetInstance() async {
     });
     _connecting = false;
     if (userInitialized) {
-      _clientEventStreamController.sink.add(
-        LiveQueryClientEvent.userDisconnected,
-      );
+      _safeAddEvent(LiveQueryClientEvent.userDisconnected);
     }
   }
 
@@ -354,9 +361,8 @@ static Future<void> resetInstance() async {
           chanelStream?.sink.add(message);
         },
         onDone: () {
-          _clientEventStreamController.sink.add(
-            LiveQueryClientEvent.disconnected,
-          );
+         _safeAddEvent(LiveQueryClientEvent.disconnected);
+
           if (_debug) {
             print('$_printConstLiveQuery: Done');
           }
@@ -382,7 +388,7 @@ static Future<void> resetInstance() async {
       );
     } on Exception catch (e) {
       _connecting = false;
-      _clientEventStreamController.sink.add(LiveQueryClientEvent.disconnected);
+      _safeAddEvent(LiveQueryClientEvent.disconnected);
       if (_debug) {
         print('$_printConstLiveQuery: Error: ${e.toString()}');
       }
@@ -482,7 +488,7 @@ static Future<void> resetInstance() async {
       _requestSubscription.values.toList().forEach((Subscription subscription) {
         _subscribeLiveQuery(subscription);
       });
-      _clientEventStreamController.sink.add(LiveQueryClientEvent.connected);
+_safeAddEvent(LiveQueryClientEvent.connected);
       return;
     }
     if (actionData.containsKey('requestId')) {

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -210,6 +210,28 @@ class LiveQueryClient {
     return parse_web_socket.WebSocket.connecting;
   }
 
+  /// Removes all subscriptions from the internal map.
+/// Call before disconnect when leaving a live room.
+void clearAllSubscriptions() {
+  _requestSubscription.values.toList().forEach((sub) {
+    sub._enabled = false;
+  });
+  _requestSubscription.clear();
+}
+  /// Fully resets the singleton — clears subscriptions, closes socket,
+/// nulls the instance so the next LiveQueryClient() call starts fresh.
+/// Use userInitialized: false so reconnect still works after reset.
+static Future<void> resetInstance() async {
+  final existing = _instance;
+  if (existing != null) {
+    existing.clearAllSubscriptions();
+    try {
+      await existing.disconnect(userInitialized: false);
+    } catch (_) {}
+  }
+  _instance = null;
+  _requestIdCount = 1;
+}
   Future<dynamic> disconnect({bool userInitialized = false}) async {
     parse_web_socket.WebSocket? webSocket = _webSocket;
     if (webSocket != null &&
@@ -262,21 +284,21 @@ class LiveQueryClient {
   }
 
   void unSubscribe<T extends ParseObject>(Subscription<T> subscription) {
-    //Mount message for Unsubscribe
-    final Map<String, dynamic> unsubscribeMessage = <String, dynamic>{
-      'op': 'unsubscribe',
-      'requestId': subscription.requestId,
-    };
-    WebSocketChannel? channel = _channel;
-    if (channel != null) {
-      if (_debug) {
-        print('$_printConstLiveQuery: UnsubscribeMessage: $unsubscribeMessage');
-      }
-      channel.sink.add(jsonEncode(unsubscribeMessage));
-      subscription._enabled = false;
-      _requestSubscription.remove(subscription.requestId);
+  final Map<String, dynamic> unsubscribeMessage = <String, dynamic>{
+    'op': 'unsubscribe',
+    'requestId': subscription.requestId,
+  };
+  WebSocketChannel? channel = _channel;
+  if (channel != null) {
+    if (_debug) {
+      print('$_printConstLiveQuery: UnsubscribeMessage: $unsubscribeMessage');
     }
+    channel.sink.add(jsonEncode(unsubscribeMessage));
   }
+  // Always remove from map regardless of socket state
+  subscription._enabled = false;
+  _requestSubscription.remove(subscription.requestId);
+}
 
   static int _requestIdCount = 1;
 


### PR DESCRIPTION
## Problem

When `unSubscribe()` is called after the WebSocket is already closed,
the `_requestSubscription` map entry is never removed because the
removal was gated inside `if (channel != null)`.

This causes ghost subscriptions to accumulate in the map. On every
WebSocket reconnect, the `connected` handler iterates the map and
re-sends subscribe messages for all entries — including stale ones
from previous sessions that should have been cleaned up.

## Root Cause

```dart
void unSubscribe(Subscription subscription) {
  WebSocketChannel? channel = _channel;
  if (channel != null) {
    channel.sink.add(jsonEncode(unsubscribeMessage));
    subscription._enabled = false;
    _requestSubscription.remove(subscription.requestId); // ← never reached if socket closed
  }
  // if channel is null → entry stays in map forever
}
```

A common teardown pattern is:

```dart
client.unSubscribe(sub);
await client.disconnect();
```

In this case `unSubscribe` works correctly. But if `disconnect()` is
called first — or if the socket drops before `unSubscribe` is called —
the channel is already null and the map entry is never removed.

## Changes

### 1. Fix `unSubscribe` — always remove from map

The unsubscribe op is only sent over the socket if the channel is open
(correct behaviour), but `_enabled = false` and map removal now always
execute regardless of socket state.

```dart
void unSubscribe(Subscription subscription) {
  WebSocketChannel? channel = _channel;
  if (channel != null) {
    channel.sink.add(jsonEncode(unsubscribeMessage));
  }
  subscription._enabled = false;
  _requestSubscription.remove(subscription.requestId);
}
```

### 2. Add `removeSubscriptions(List<Subscription> subs)`

Removes a targeted set of subscriptions from the internal map without
affecting others. Useful when multiple independent features share the
same singleton client and only one group needs to be torn down.

```dart
void removeSubscriptions(List<Subscription> subs) {
  for (final sub in subs) {
    sub._enabled = false;
    _requestSubscription.remove(sub.requestId);
  }
}
```

### 3. Add `clearAllSubscriptions()`

Disables and removes all entries from `_requestSubscription` without
closing the socket.

```dart
void clearAllSubscriptions() {
  _requestSubscription.values.toList().forEach((sub) {
    sub._enabled = false;
  });
  _requestSubscription.clear();
}
```

### 4. Add `resetInstance()`

Full singleton reset for cases where a completely fresh client is
needed. Clears all subscriptions, closes the socket, and nulls the
singleton so the next `LiveQueryClient()` call creates a new instance.
Uses `userInitialized: false` so the reconnecting controller remains
active after reset.

```dart
static Future<void> resetInstance() async {
  final existing = _instance;
  if (existing != null) {
    existing.clearAllSubscriptions();
    try {
      await existing.disconnect(userInitialized: false);
    } catch (_) {}
  }
  _instance = null;
  _requestIdCount = 1;
}
```

## Impact

- No breaking changes — existing `unSubscribe` call signature unchanged
- Ghost subscriptions no longer accumulate after socket closes
- Reconnect only re-subscribes entries still present in the map
- New utility methods give callers explicit control over subscription
  lifecycle without workarounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remove specific live-query subscriptions, clear all active subscriptions, and fully reset the live-query client to a fresh state.

* **Improvements**
  * Safer event emission to the live-query stream when the client is closed.
  * Unsubscribe flow now always disables and removes local subscriptions and only sends network unsubscribe when connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->