### PR TITLE
ci: Bump actions/github-script from 8 to 9

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -82,7 +82,7 @@ jobs:
     if: failure()
     steps:
       - name: Create issue for security vulnerabilities
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '[Security] Dependency vulnerabilities detected';


### PR DESCRIPTION
Closes #1131

Bumps the `actions/github-script` GitHub Action from **v8 to v9** (major version bump) in `.github/workflows/dependency-audit.yml`. Replacement for the Dependabot PR #1131 (identical one-line change: `actions/github-script@v8` -> `actions/github-script@v9`).

### Changes (v9.0.0)

- **New:** injected `getOctokit` factory function available directly in the script context (multi-token / GitHub App / cross-org clients).
- **New:** `ACTIONS_ORCHESTRATION_ID` appended to the user-agent for request tracing.
- Upgrades bundled `@actions/github` to v9 (ESM-only), `@octokit/core` to v7, and related packages.

### Breaking Changes (from v9.0.0 release notes)

- `require('@actions/github')` no longer works inside scripts (the bundled `@actions/github` is now ESM-only).
- `getOctokit` is now an injected function parameter, so scripts that declare `const getOctokit = ...` / `let getOctokit = ...` will throw a `SyntaxError`.
- Scripts touching other `@actions/github` internals beyond the standard `github`/`octokit` client may need updates.

### Breaking Changes assessment: none affect this repo

The only `github-script` step (`create-issue` job in `dependency-audit.yml`) uses only `context` and `github.rest.issues.*`. It does not `require('@actions/github')`, does not declare `getOctokit`, and does not access any `@actions/github` internals. The upgrade is a drop-in replacement with no script changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the monthly dependency audit process to use the latest supported workflow action.
  * Existing vulnerability checks and issue reporting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->