### PR TITLE
ci: Bump codecov/codecov-action from 6 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage -i coverage/test -o coverage/lcov.info --lcov --packages=.dart_tool/package_config.json --report-on=lib
       - name: Upload code coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         with:
@@ -141,7 +141,7 @@ jobs:
           escapedPath="$(echo `pwd` | sed 's/\//\\\//g')"
           sed "s/^SF:lib/SF:$escapedPath\/lib/g" coverage/lcov.info > coverage/lcov-full.info
       - name: Upload code coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         # Needs to be adapted to collect the coverage at all platforms if platform specific code is added.
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         with:


### PR DESCRIPTION
Closes #1143

Bumps the `codecov/codecov-action` GitHub Action from major `v6` to `v7` in `.github/workflows/ci.yml` (two usages, in the Dart and Flutter coverage-upload steps). This is a like-for-like replacement of Dependabot PR #1143, authored under a maintainer identity.

### Changes

- **v7.0.0**: Maintenance-only major release. The only merged changes are internal to the action's own repository: removal of the "Enforce License Compliance" workflow (codecov/codecov-action#1950) and the release chore (codecov/codecov-action#1957). See the [v6.0.1...v7.0.0 comparison](https://github.com/codecov/codecov-action/compare/v6.0.1...v7.0.0). The release note also mentions a GPG signing-key account migration (`codecovsecurity` -> `codecovsecops`) using the original key.

### Input / Behavior Changes

None affecting this repository. No action inputs were added, removed, or renamed. The existing inputs used here (`files`, `fail_ci_if_error`) are unchanged and continue to work with v7.

### Breaking Changes

None for consumers. The v7 major bump does not change the action's input contract or runtime behavior for the way this workflow uses it; the changes in the release are confined to the action's own repository tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code coverage reporting to use the latest Codecov upload action.
  * No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->