### PR TITLE
ci: Bump actions/deploy-pages from 4 to 5

### DIFF
--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -51,4 +51,4 @@ jobs:
           path: ./.api_docs/${{ env.package }}/
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -102,7 +102,7 @@ jobs:
           path: ./.api_docs/dart/
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   docs-publish-flutter:
     if: startsWith(github.ref_name, 'flutter-')
@@ -142,4 +142,4 @@ jobs:
           path: ./.api_docs/flutter/
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes #1130

Bumps `actions/deploy-pages` from v4 to v5 across the release workflows (`release-manual-docs.yml` and `release-publish.yml`, 3 occurrences).

### Changes

- **v5.0.0**: Updates the action's JavaScript runtime from Node.js 20 to Node.js 24 (actions/deploy-pages#404). This runtime upgrade is the sole reason for the major version bump.

### Breaking Changes

None affecting these workflows. Verified `action.yml` between `v4.0.5` and `v5.0.0`: the only difference is `runs.using: 'node20'` -> `'node24'`. All inputs (`token`, `timeout`, `error_count`, `reporting_interval`, `artifact_name`, `preview`) and the `page_url` output are unchanged. Node.js 24 is supported on GitHub-hosted `ubuntu-latest` runners used by these jobs.

### Code Changes Required

None — drop-in replacement, action version tag change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing process to use the latest GitHub Pages deployment action.
  * No changes to package publishing or documentation generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->