### PR TITLE
ci: Bump actions/configure-pages from 5 to 6

### DIFF
--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate Docs
         run: dart doc ./packages/${{ env.package }}/ -o ./.api_docs/${{ env.package }}/
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Generate Docs
         run: dart doc ./packages/dart/ -o ./.api_docs/dart/
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
       - name: Generate Docs
         run: dart doc ./packages/flutter/ -o ./.api_docs/flutter/
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
Bumps the `actions/configure-pages` GitHub Action from v5 to v6 across the release workflows. Replaces #1132 (Dependabot) with a commit under the maintainer identity.

### Changes

- **v6.0.0**: The action's JavaScript runtime was upgraded from Node 20 to Node 24. No action inputs or outputs were changed; there are no new required inputs and no defaults were altered.

Affected workflow files:
- `.github/workflows/release-manual-docs.yml`
- `.github/workflows/release-publish.yml` (2 occurrences)

In all cases the action is invoked as `uses: actions/configure-pages@v6` with no `with:` inputs, so the runtime bump is the only relevant change.

### Breaking Changes

None affecting these workflows. The only major-version change is the internal Node 20 -> Node 24 runtime upgrade, which is transparent to GitHub-hosted `ubuntu-latest` runners used here. The action's input/output interface is unchanged.

### Code Changes Required

None -- drop-in replacement (workflow YAML version tag only).

Closes #1132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use the latest GitHub Pages configuration action.
  * Applied the update consistently to both Dart and Flutter documentation deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->