### PR TITLE
ci: Bump actions/upload-pages-artifact from 4 to 5

### DIFF
--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./.api_docs/${{ env.package }}/
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./.api_docs/dart/
       - name: Deploy to GitHub Pages
@@ -137,7 +137,7 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./.api_docs/flutter/
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Closes #1133

Bumps `actions/upload-pages-artifact` from `v4` to `v5` in the GitHub Pages steps of `release-manual-docs.yml` and `release-publish.yml` (3 occurrences total). Replacement for the Dependabot PR so the commit lands under a maintainer identity.

### Changes (v4 -> v5)

- **Update internal `actions/upload-artifact` to v7.0.0**: the composite action now delegates to `actions/upload-artifact@v7`, which runs on the Node 24 runtime (addresses the [deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
- **New `include-hidden-files` input** (default `false`): additive, opt-in. Default behavior is unchanged from v4 (dotfiles remain excluded from the artifact; `.git`/`.github` always excluded).

### Breaking Changes

None affecting these workflows. The only input used here is `path`, whose name, semantics, and default are unchanged in v5. The new `include-hidden-files` input is additive with a default that preserves prior behavior. The v5 major bump is driven by the internal runtime upgrade (upload-artifact v7 / Node 24), which is supported by current GitHub-hosted runners.

### Code Changes Required

None — drop-in version tag bump only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use the latest GitHub Pages artifact upload action.
  * Applied the update to API, Dart, and Flutter documentation publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->