### PR TITLE
refactor: Bump semantic-release from 25.0.6 to 25.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/release-notes-generator": "14.1.1",
-        "semantic-release": "25.0.6",
+        "semantic-release": "25.0.8",
         "semantic-release-monorepo": "8.0.2"
       }
     },
@@ -5625,9 +5625,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.6",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.6.tgz",
-      "integrity": "sha512-EGS5PWCDavYD4jAE4vKQ+VKcwXFpxLsKg05UcrUQwqxUCM1KtNRx9ZdMyYJL3z2aTyAH9zDgQSNFjRvbsIuKHQ==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "semantic-release": "25.0.6",
+    "semantic-release": "25.0.8",
     "semantic-release-monorepo": "8.0.2"
   }
 }


### PR DESCRIPTION
Bumps [semantic-release](https://github.com/semantic-release/semantic-release) devDependency from 25.0.6 to 25.0.8.

Replaces the Dependabot PR so the commit is authored under the maintainer identity.

Closes #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release tooling patch version to a newer release to improve compatibility and reliability for automated releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->