### PR TITLE
feat: Add ParseObjectOffline extension and fix LiveQuery, serialization and CoreStore defects

### DIFF
--- a/packages/dart/lib/parse_server_sdk.dart
+++ b/packages/dart/lib/parse_server_sdk.dart
@@ -84,6 +84,8 @@ part 'src/utils/parse_login_helpers.dart';
 part 'src/utils/parse_utils.dart';
 part 'src/utils/valuable.dart';
 
+part 'src/objects/parse_offline_object.dart';
+
 class Parse {
   bool _hasBeenInitialized = false;
 

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -7,12 +7,22 @@ const String _printConstLiveQuery = 'LiveQuery: ';
 class Subscription<T extends ParseObject> {
   Subscription(this.query, this.requestId, {T? copyObject}) {
     _copyObject = copyObject;
+    // Captured up front because _subscribeLiveQuery clears query.limiters to
+    // strip the limits LiveQuery does not accept. That is destructive, so by
+    // the time the subscription is re-sent on reconnect the 'keys' limiter is
+    // gone and the payload would silently omit 'fields' — the server would
+    // then push full objects instead of the selected columns.
+    _keysToReturn = query.limiters['keys']?.split(',');
   }
 
   QueryBuilder<T> query;
   T? _copyObject;
   int requestId;
   bool _enabled = false;
+
+  /// The `keys` limiter as it was when this subscription was created, so every
+  /// subscribe message for it carries the same `fields` list.
+  List<String>? _keysToReturn;
   final List<String> _liveQueryEvent = <String>[
     'create',
     'enter',
@@ -327,7 +337,7 @@ class LiveQueryClient {
         if (_debug) {
           print('$_printConstLiveQuery: Error when connection client');
         }
-        // Plain  rather than a Future: this is an async body, so
+        // Plain `null` rather than a Future: this is an async body, so
         // returning a Future inside the try block trips
         // unawaited_return_in_try_block on newer analyzers.
         return null;
@@ -426,7 +436,7 @@ class LiveQueryClient {
     }
     subscription._enabled = true;
     final QueryBuilder query = subscription.query;
-    final List<String>? keysToReturn = query.limiters['keys']?.split(',');
+    final List<String>? keysToReturn = subscription._keysToReturn;
     query.limiters.clear(); //Remove limits in LiveQuery
     final String where = query.buildQuery().replaceAll('where=', '');
 

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -214,7 +214,32 @@ class LiveQueryClient {
 
   final Map<int, Subscription> _requestSubscription = <int, Subscription>{};
 
-  Future<void> reconnect({bool userInitialized = false}) async {
+  /// Coalesces concurrent reconnects onto one in-flight attempt.
+  ///
+  /// `_connect` guards on `_connecting`, but only sets it AFTER `await
+  /// disconnect(...)` — and `disconnect` itself clears it — so two callers can
+  /// both pass the guard while the first is suspended at that await and open
+  /// two sockets. `subscribe` makes this easy to hit, because it starts a
+  /// reconnect without awaiting it, so a burst of subscriptions all reach here
+  /// before any connection exists.
+  Future<void>? _reconnectFuture;
+
+  Future<void> reconnect({bool userInitialized = false}) {
+    final Future<void>? inFlight = _reconnectFuture;
+    if (inFlight != null) {
+      return inFlight;
+    }
+    late final Future<void> attempt;
+    attempt = _reconnect(userInitialized: userInitialized).whenComplete(() {
+      if (identical(_reconnectFuture, attempt)) {
+        _reconnectFuture = null;
+      }
+    });
+    _reconnectFuture = attempt;
+    return attempt;
+  }
+
+  Future<void> _reconnect({bool userInitialized = false}) async {
     await _connect(userInitialized: userInitialized);
     await _connectLiveQuery();
   }
@@ -291,23 +316,32 @@ class LiveQueryClient {
       'op': 'unsubscribe',
       'requestId': subscription.requestId,
     };
+    // Drop the LOCAL state FIRST, unconditionally. Telling the server is
+    // best-effort — it only has a socket to hear it on, and a non-null channel
+    // does not prove the sink still accepts writes. Both used to sit inside the
+    // channel guard, so unsubscribing while disconnected (app backgrounded,
+    // socket dropped) was a silent no-op: the entry stayed in
+    // _requestSubscription and was resurrected by the re-subscribe on
+    // reconnect. Callers that cancel-and-resubscribe therefore accumulated a
+    // duplicate per cycle, and every event fired their handler once per
+    // accumulated subscription. Ordering the removal first means a throwing
+    // sink cannot resurrect it either.
+    subscription._enabled = false;
+    _requestSubscription.remove(subscription.requestId);
+
     WebSocketChannel? channel = _channel;
     if (channel != null) {
       if (_debug) {
         print('$_printConstLiveQuery: UnsubscribeMessage: $unsubscribeMessage');
       }
-      channel.sink.add(jsonEncode(unsubscribeMessage));
+      try {
+        channel.sink.add(jsonEncode(unsubscribeMessage));
+      } catch (e) {
+        if (_debug) {
+          print('$_printConstLiveQuery: Unsubscribe send failed: $e');
+        }
+      }
     }
-    // Forget the subscription even with no live channel. Telling the server is
-    // best-effort — it only has a socket to hear it on — but the LOCAL state
-    // must always be dropped. Previously both were inside the channel guard, so
-    // unsubscribing while disconnected (app backgrounded, socket dropped) was a
-    // silent no-op: the entry stayed in _requestSubscription and was
-    // resurrected by the re-subscribe on reconnect. Callers that
-    // cancel-and-resubscribe therefore accumulated a duplicate per cycle, and
-    // every event fired their handler once per accumulated subscription.
-    subscription._enabled = false;
-    _requestSubscription.remove(subscription.requestId);
   }
 
   static int _requestIdCount = 1;
@@ -337,6 +371,12 @@ class LiveQueryClient {
         if (_debug) {
           print('$_printConstLiveQuery: Error when connection client');
         }
+        // Drop the handle for a socket that never opened. `subscribe` only
+        // starts recovery when _webSocket == null, so leaving this assigned
+        // parks every later subscription behind a socket that will never
+        // complete a handshake.
+        _webSocket = null;
+        _connected = false;
         // Plain `null` rather than a Future: this is an async body, so
         // returning a Future inside the try block trips
         // unawaited_return_in_try_block on newer analyzers.
@@ -351,6 +391,13 @@ class LiveQueryClient {
           chanelStream?.sink.add(message);
         },
         onDone: () {
+          // Clear the handles for THIS socket, so the _webSocket == null check
+          // in subscribe can trigger a fresh connection. Guarded on identity so
+          // a reconnect that already swapped in a new socket is left alone.
+          if (identical(_webSocket, webSocket)) {
+            _webSocket = null;
+            _channel = null;
+          }
           _connected = false;
           _clientEventStreamController.sink.add(
             LiveQueryClientEvent.disconnected,
@@ -360,6 +407,10 @@ class LiveQueryClient {
           }
         },
         onError: (Object error) {
+          if (identical(_webSocket, webSocket)) {
+            _webSocket = null;
+            _channel = null;
+          }
           _connected = false;
           _clientEventStreamController.sink.add(
             LiveQueryClientEvent.disconnected,

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -190,6 +190,13 @@ class LiveQueryClient {
   WebSocketChannel? _channel;
   final String _liveQueryURL;
   bool _connecting = false;
+
+  /// Whether the LiveQuery `connect` handshake has been acknowledged by the
+  /// server (a `connected` op was received on the current socket). A raw socket
+  /// being open ([_webSocket] != null) is NOT enough — subscribing before this
+  /// is true yields "Can not find this client" and leaves the subscription
+  /// stuck. Reset to false whenever the socket drops.
+  bool _connected = false;
   late StreamController<LiveQueryClientEvent> _clientEventStreamController;
   late Stream<LiveQueryClientEvent> _clientEventStream;
   StreamController<String>? chanelStream;
@@ -232,6 +239,7 @@ class LiveQueryClient {
       subscription._enabled = false;
     });
     _connecting = false;
+    _connected = false;
     if (userInitialized) {
       _clientEventStreamController.sink.add(
         LiveQueryClientEvent.userDisconnected,
@@ -243,21 +251,27 @@ class LiveQueryClient {
     QueryBuilder<T> query, {
     T? copyObject,
   }) async {
-    if (_webSocket == null) {
-      await _clientEventStream.any(
-        (LiveQueryClientEvent event) => event == LiveQueryClientEvent.connected,
-      );
-    }
     final int requestId = _requestIdGenerator();
     final Subscription<T> subscription = Subscription<T>(
       query,
       requestId,
       copyObject: copyObject,
     );
+    // Always register the subscription so the `connected` handler can (re)send
+    // it. Only send the subscribe now if the LiveQuery handshake is already
+    // acknowledged — sending before that yields "Can not find this client" and,
+    // because _subscribeLiveQuery marks it _enabled, the connected handler would
+    // then skip it, leaving it permanently unregistered.
     _requestSubscription[requestId] = subscription;
-    //After a client connects to the LiveQuery server,
-    //it can send a subscribe message to subscribe a ParseQuery.
-    _subscribeLiveQuery(subscription);
+    if (_connected) {
+      //After a client connects to the LiveQuery server,
+      //it can send a subscribe message to subscribe a ParseQuery.
+      _subscribeLiveQuery(subscription);
+    } else if (_webSocket == null && !_connecting) {
+      // No live connection yet — open one. The `connected` handler then sends
+      // this (and every other pending) subscription.
+      reconnect();
+    }
     return subscription;
   }
 
@@ -273,9 +287,17 @@ class LiveQueryClient {
         print('$_printConstLiveQuery: UnsubscribeMessage: $unsubscribeMessage');
       }
       channel.sink.add(jsonEncode(unsubscribeMessage));
-      subscription._enabled = false;
-      _requestSubscription.remove(subscription.requestId);
     }
+    // Forget the subscription even with no live channel. Telling the server is
+    // best-effort — it only has a socket to hear it on — but the LOCAL state
+    // must always be dropped. Previously both were inside the channel guard, so
+    // unsubscribing while disconnected (app backgrounded, socket dropped) was a
+    // silent no-op: the entry stayed in _requestSubscription and was
+    // resurrected by the re-subscribe on reconnect. Callers that
+    // cancel-and-resubscribe therefore accumulated a duplicate per cycle, and
+    // every event fired their handler once per accumulated subscription.
+    subscription._enabled = false;
+    _requestSubscription.remove(subscription.requestId);
   }
 
   static int _requestIdCount = 1;
@@ -316,6 +338,7 @@ class LiveQueryClient {
           chanelStream?.sink.add(message);
         },
         onDone: () {
+          _connected = false;
           _clientEventStreamController.sink.add(
             LiveQueryClientEvent.disconnected,
           );
@@ -324,6 +347,7 @@ class LiveQueryClient {
           }
         },
         onError: (Object error) {
+          _connected = false;
           _clientEventStreamController.sink.add(
             LiveQueryClientEvent.disconnected,
           );
@@ -439,9 +463,14 @@ class LiveQueryClient {
 
     Subscription? subscription;
     if (actionData.containsKey('op') && actionData['op'] == 'connected') {
-      print('Re subscription:$_requestSubscription');
-
+      // The handshake is acknowledged — safe to (re)send subscribes now.
+      _connected = true;
       _requestSubscription.values.toList().forEach((Subscription subscription) {
+        // This is a fresh connection, so the server has no record of any prior
+        // subscribe. Force a re-send by clearing _enabled first — otherwise the
+        // guard in _subscribeLiveQuery skips already-enabled subscriptions and
+        // they never re-register after a (re)connect.
+        subscription._enabled = false;
         _subscribeLiveQuery(subscription);
       });
       _clientEventStreamController.sink.add(LiveQueryClientEvent.connected);

--- a/packages/dart/lib/src/network/parse_live_query.dart
+++ b/packages/dart/lib/src/network/parse_live_query.dart
@@ -327,7 +327,10 @@ class LiveQueryClient {
         if (_debug) {
           print('$_printConstLiveQuery: Error when connection client');
         }
-        return Future<void>.value(null);
+        // Plain  rather than a Future: this is an async body, so
+        // returning a Future inside the try block trips
+        // unawaited_return_in_try_block on newer analyzers.
+        return null;
       }
       WebSocketChannel channel = webSocket.createWebSocketChannel();
       _channel = channel;

--- a/packages/dart/lib/src/objects/parse_config.dart
+++ b/packages/dart/lib/src/objects/parse_config.dart
@@ -2,13 +2,8 @@ part of '../../parse_server_sdk.dart';
 
 class ParseConfig extends ParseObject {
   /// Creates an instance of ParseConfig so that you can grab all configs from the server
-  ParseConfig({bool? debug, ParseClient? client, bool? autoSendSessionId})
-    : super(
-        'config',
-        debug: debug,
-        client: client,
-        autoSendSessionId: autoSendSessionId,
-      );
+  ParseConfig({super.debug, super.client, super.autoSendSessionId})
+    : super('config');
 
   /// Gets all configs from the server
   Future<ParseResponse> getConfigs() async {

--- a/packages/dart/lib/src/objects/parse_function.dart
+++ b/packages/dart/lib/src/objects/parse_function.dart
@@ -6,15 +6,10 @@ class ParseCloudFunction extends ParseObject {
   /// {https://docs.parseplatform.org/cloudcode/guide/}
   ParseCloudFunction(
     this.functionName, {
-    bool? debug,
-    ParseClient? client,
-    bool? autoSendSessionId,
-  }) : super(
-         functionName,
-         client: client,
-         autoSendSessionId: autoSendSessionId,
-         debug: debug,
-       ) {
+    super.debug,
+    super.client,
+    super.autoSendSessionId,
+  }) : super(functionName) {
     _path = '/functions/$functionName';
   }
 

--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -405,39 +405,55 @@ class ParseObject extends ParseBase implements ParseCloneable {
     return request;
   }
 
-  bool _canbeSerialized(List<dynamic> aftersaving, {dynamic value}) {
-    if (value != null) {
-      if (value is ParseObject) {
-        if (value is ParseFileBase) {
-          if (!value.saved && !aftersaving.contains(value)) {
-            return false;
-          }
-        } else if (value.objectId == null && !aftersaving.contains(value)) {
+  // Sentinel distinguishing "no value argument" (the entry call, which must
+  // validate this object's whole field graph) from an explicitly-passed `null`
+  // field value. Previously both looked like `value == null`, so a null value
+  // inside the object's data map re-entered the whole-object branch and recursed
+  // into _getObjectData() forever -> Stack Overflow. This surfaced on offline
+  // saveEventually() (submitSaveEventually -> _saveChildren -> here), e.g. an
+  // Installation/analytics save with a null field on a no-network cold launch.
+  static const Object _canbeSerializedUnset = Object();
+
+  bool _canbeSerialized(
+    List<dynamic> aftersaving, {
+    Object? value = _canbeSerializedUnset,
+  }) {
+    if (identical(value, _canbeSerializedUnset)) {
+      // Entry point: validate this object's own field data.
+      return _canbeSerialized(aftersaving, value: _getObjectData());
+    }
+    if (value == null) {
+      // A null field is trivially serializable — nothing to recurse into.
+      return true;
+    }
+    if (value is ParseObject) {
+      if (value is ParseFileBase) {
+        if (!value.saved && !aftersaving.contains(value)) {
           return false;
         }
-      } else if (value is Map) {
-        for (dynamic child in value.values) {
-          if (!_canbeSerialized(aftersaving, value: child)) {
-            return false;
-          }
-        }
-      } else if (value is _Valuable) {
-        if (!_canbeSerialized(aftersaving, value: value.getValue())) {
+      } else if (value.objectId == null && !aftersaving.contains(value)) {
+        return false;
+      }
+    } else if (value is Map) {
+      for (dynamic child in value.values) {
+        if (!_canbeSerialized(aftersaving, value: child)) {
           return false;
-        }
-      } else if (value is _ParseRelation) {
-        if (!_canbeSerialized(aftersaving, value: value.valueForApiRequest())) {
-          return false;
-        }
-      } else if (value is Iterable) {
-        for (dynamic child in value) {
-          if (!_canbeSerialized(aftersaving, value: child)) {
-            return false;
-          }
         }
       }
-    } else if (!_canbeSerialized(aftersaving, value: _getObjectData())) {
-      return false;
+    } else if (value is _Valuable) {
+      if (!_canbeSerialized(aftersaving, value: value.getValue())) {
+        return false;
+      }
+    } else if (value is _ParseRelation) {
+      if (!_canbeSerialized(aftersaving, value: value.valueForApiRequest())) {
+        return false;
+      }
+    } else if (value is Iterable) {
+      for (dynamic child in value) {
+        if (!_canbeSerialized(aftersaving, value: child)) {
+          return false;
+        }
+      }
     }
     // TODO(yulingtianxia): handle ACL
     return true;

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -71,9 +71,17 @@ Future<R> _withOfflineCacheLock<R>(
 
 String _offlineCacheKey(String className) {
   final String? namespace = ParseObjectOffline.cacheNamespace;
-  return namespace == null || namespace.isEmpty
-      ? 'offline_cache_$className'
-      : 'offline_cache_${namespace}_$className';
+  if (namespace == null || namespace.isEmpty) {
+    return 'offline_cache_$className';
+  }
+  // ':' as the separator, and the namespace percent-encoded. Joining with '_'
+  // was ambiguous, because class names legitimately contain underscores
+  // (_User, _Installation): namespace 'a_b' + class 'c' and namespace 'a' +
+  // class 'b_c' both produced 'offline_cache_a_b_c', so two accounts could
+  // land in one bucket — exactly what the namespace exists to prevent.
+  // Uri.encodeComponent escapes ':' (and '%'), and Parse class names cannot
+  // contain ':', so the two halves can never be confused.
+  return 'offline_cache_${Uri.encodeComponent(namespace)}:$className';
 }
 
 extension ParseObjectOffline on ParseObject {
@@ -150,7 +158,14 @@ extension ParseObjectOffline on ParseObject {
       try {
         final Map<String, dynamic> obj =
             json.decode(existing) as Map<String, dynamic>;
-        obj.addAll(updates);
+        // Cached entries are written as `json.encode(toJson(full: true))`, so
+        // they hold Parse wire format. Raw values (DateTime, ParseObject,
+        // ParseGeoPoint, nested Maps) would either fail to encode here or
+        // decode back differently from a server response, so run the caller's
+        // values through the same encoder first.
+        updates.forEach((String key, dynamic value) {
+          obj[key] = parseEncode(value, full: true);
+        });
         map[id] = json.encode(obj);
         await _saveMap(store, cacheKey, map);
         if (isDebugEnabled()) {

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -357,7 +357,14 @@ extension ParseObjectOffline on ParseObject {
       // and made this a silent no-op.
       await store.remove(_offlineMapKey(cacheKey));
       await store.remove(_legacyOfflineMapKey(cacheKey));
-      await store.remove(cacheKey);
+      // The oldest list-format key is the bare cacheKey — but for a class
+      // named 'X_v2' that is 'offline_cache_X_v2', which is also class X's
+      // UNMIGRATED map. Removing it blindly would delete X's cache before X
+      // ever loaded. A list-format entry is a StringList and a map is a
+      // String, so only drop it when it really is a list.
+      if (await store.getStringList(cacheKey) != null) {
+        await store.remove(cacheKey);
+      }
     });
     if (isDebugEnabled()) {
       print('ParseObjectOffline: cleared cache for $className');

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -1,0 +1,293 @@
+part of '../../parse_server_sdk.dart';
+
+extension ParseObjectOffline on ParseObject {
+  // ─── Single-object operations ────────────────────────────────────────────
+
+  /// Save this object to local storage for offline access.
+  Future<void> saveToLocalCache() async {
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = 'offline_cache_$parseClassName';
+    final Map<String, String> map = await _loadMap(store, cacheKey);
+    if (objectId == null) {
+      print(
+        'ParseObjectOffline.saveToLocalCache: skipping object with no objectId '
+        'for $parseClassName',
+      );
+      return;
+    }
+    map[objectId!] = json.encode(toJson(full: true));
+    await _saveMap(store, cacheKey, map);
+    print('ParseObjectOffline: saved $objectId to cache for $parseClassName');
+  }
+
+  /// Remove this object from local storage.
+  Future<void> removeFromLocalCache() async {
+    if (objectId == null) return;
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = 'offline_cache_$parseClassName';
+    final Map<String, String> map = await _loadMap(store, cacheKey);
+    if (map.remove(objectId) != null) {
+      await _saveMap(store, cacheKey, map);
+      print(
+        'ParseObjectOffline: removed $objectId from cache for $parseClassName',
+      );
+    }
+  }
+
+  /// Partially update a cached object's fields without a full re-encode.
+  ///
+  /// Returns `true` if the object was found and updated.
+  Future<bool> updateInLocalCache(Map<String, dynamic> updates) async {
+    if (objectId == null) return false;
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = 'offline_cache_$parseClassName';
+    final Map<String, String> map = await _loadMap(store, cacheKey);
+    final String? existing = map[objectId];
+    if (existing == null) return false;
+    try {
+      final Map<String, dynamic> obj =
+          json.decode(existing) as Map<String, dynamic>;
+      obj.addAll(updates);
+      map[objectId!] = json.encode(obj);
+      await _saveMap(store, cacheKey, map);
+      print(
+        'ParseObjectOffline: updated $objectId in cache for $parseClassName',
+      );
+      return true;
+    } catch (e) {
+      print('ParseObjectOffline.updateInLocalCache: error for $objectId: $e');
+      return false;
+    }
+  }
+
+  // ─── Batch / static operations ───────────────────────────────────────────
+
+  /// Load a single object by objectId from local storage. O(1) lookup.
+  static Future<ParseObject?> loadFromLocalCache(
+    String className,
+    String objectId,
+  ) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final Map<String, String> map = await _loadMap(
+      store,
+      'offline_cache_$className',
+    );
+    final String? raw = map[objectId];
+    if (raw == null) return null;
+    try {
+      return ParseObject(
+        className,
+      ).fromJson(json.decode(raw) as Map<String, dynamic>);
+    } catch (e) {
+      print(
+        'ParseObjectOffline.loadFromLocalCache: corrupt entry for $objectId '
+        'in $className — $e',
+      );
+      return null;
+    }
+  }
+
+  /// Load all objects of a class from local storage.
+  /// Load every cached object of [className].
+  ///
+  /// The offline store holds one bucket per class, so callers that only want a
+  /// subset (e.g. the messages of ONE conversation) can pass [where] to filter
+  /// during the load — non-matching entries are skipped without being added to
+  /// the result. Without it, ALL cached objects of the class are returned.
+  static Future<List<ParseObject>> loadAllFromLocalCache(
+    String className, {
+    bool Function(ParseObject object)? where,
+  }) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final Map<String, String> map = await _loadMap(
+      store,
+      'offline_cache_$className',
+    );
+    final List<ParseObject> results = [];
+    for (final entry in map.entries) {
+      try {
+        final ParseObject object = ParseObject(
+          className,
+        ).fromJson(json.decode(entry.value) as Map<String, dynamic>);
+        if (where == null || where(object)) {
+          results.add(object);
+        }
+      } catch (e) {
+        print(
+          'ParseObjectOffline.loadAllFromLocalCache: skipping corrupt entry '
+          '${entry.key} for $className — $e',
+        );
+      }
+    }
+    print(
+      'ParseObjectOffline: loaded ${results.length} objects from cache for '
+      '$className${where != null ? ' (filtered)' : ''}',
+    );
+    return results;
+  }
+
+  /// Save a batch of objects efficiently. O(1) per object — no re-read needed.
+  static Future<void> saveAllToLocalCache(
+    String className,
+    List<ParseObject> objects,
+  ) async {
+    if (objects.isEmpty) return;
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = 'offline_cache_$className';
+    final Map<String, String> map = await _loadMap(store, cacheKey);
+
+    int added = 0;
+    int updated = 0;
+    int failed = 0;
+    for (final obj in objects) {
+      final id = obj.objectId;
+      if (id == null) {
+        print(
+          'ParseObjectOffline.saveAllToLocalCache: skipping object without '
+          'objectId for $className',
+        );
+        continue;
+      }
+      // Encode each object independently so one bad object (e.g. a value that
+      // fails to serialize) can't abort the whole batch and prevent every other
+      // item — including a freshly-added one — from being cached.
+      try {
+        final encoded = json.encode(obj.toJson(full: true));
+        map.containsKey(id) ? updated++ : added++;
+        map[id] = encoded;
+      } catch (e) {
+        failed++;
+        print(
+          'ParseObjectOffline.saveAllToLocalCache: skipping object $id '
+          '(createdAt=${obj.createdAt?.toIso8601String()}) for '
+          '$className — encode failed: $e',
+        );
+      }
+    }
+
+    await _saveMap(store, cacheKey, map);
+    print(
+      'ParseObjectOffline: batch saved to $className. '
+      'Added: $added, Updated: $updated, Failed: $failed, Total: ${map.length}',
+    );
+  }
+
+  /// Returns all cached objectIds for a class. O(1) — no JSON decoding.
+  static Future<List<String>> getAllObjectIdsInLocalCache(
+    String className,
+  ) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final Map<String, String> map = await _loadMap(
+      store,
+      'offline_cache_$className',
+    );
+    return map.keys.toList();
+  }
+
+  /// Returns true if an object with the given id exists in the cache. O(1).
+  static Future<bool> existsInLocalCache(
+    String className,
+    String objectId,
+  ) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final Map<String, String> map = await _loadMap(
+      store,
+      'offline_cache_$className',
+    );
+    return map.containsKey(objectId);
+  }
+
+  /// Wipes the entire cache for a class.
+  static Future<void> clearLocalCacheForClass(String className) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = 'offline_cache_$className';
+    // Remove BOTH formats. Reads and writes go through the `_v2` map key, so
+    // dropping only the legacy list key left the actual cache fully intact and
+    // made this a silent no-op.
+    await store.remove('${cacheKey}_v2');
+    await store.remove(cacheKey);
+    print('ParseObjectOffline: cleared cache for $className');
+  }
+
+  /// Sync: pushes every cached object to the server.
+  ///
+  /// Only call this when you know the local copy is authoritative (e.g. after
+  /// collecting edits while offline). Objects whose server version may be newer
+  /// should be reconciled before calling this.
+  static Future<void> syncLocalCacheWithServer(
+    String className, {
+    bool Function(ParseObject obj)? shouldSync,
+  }) async {
+    final List<ParseObject> objects = await loadAllFromLocalCache(className);
+    int synced = 0;
+    int skipped = 0;
+    for (final obj in objects) {
+      if (shouldSync != null && !shouldSync(obj)) {
+        skipped++;
+        continue;
+      }
+      final response = await obj.save();
+      if (response.success) {
+        synced++;
+      } else {
+        print(
+          'ParseObjectOffline.syncLocalCacheWithServer: failed to save '
+          '${obj.objectId} — ${response.error?.message}',
+        );
+      }
+    }
+    print(
+      'ParseObjectOffline: sync complete for $className. '
+      'Synced: $synced, Skipped: $skipped',
+    );
+  }
+
+  // ─── Internal helpers ────────────────────────────────────────────────────
+
+  // The cache is stored as a single JSON-encoded Map<String, String> keyed by
+  // objectId. This gives O(1) lookups and avoids scanning every entry for id
+  // comparisons. The old format (List<String>) is migrated on first read.
+  static Future<Map<String, String>> _loadMap(
+    CoreStore store,
+    String cacheKey,
+  ) async {
+    // Try new map format first.
+    final String? mapJson = await store.getString('${cacheKey}_v2');
+    if (mapJson != null) {
+      try {
+        final decoded = json.decode(mapJson) as Map<String, dynamic>;
+        return decoded.map((k, v) => MapEntry(k, v as String));
+      } catch (_) {}
+    }
+
+    // Migrate from old List<String> format.
+    final rawList = await store.getStringList(cacheKey);
+    if (rawList == null || rawList.isEmpty) return {};
+    final Map<String, String> migrated = {};
+    for (final s in rawList) {
+      try {
+        final obj = json.decode(s) as Map<String, dynamic>;
+        final id = obj['objectId'] as String?;
+        if (id != null) migrated[id] = s;
+      } catch (_) {}
+    }
+    if (migrated.isNotEmpty) {
+      // Write migrated data in new format and remove old list.
+      await store.setString('${cacheKey}_v2', json.encode(migrated));
+      await store.remove(cacheKey);
+      print(
+        'ParseObjectOffline: migrated ${migrated.length} entries from list '
+        'format to map format for $cacheKey',
+      );
+    }
+    return migrated;
+  }
+
+  static Future<void> _saveMap(
+    CoreStore store,
+    String cacheKey,
+    Map<String, String> map,
+  ) async {
+    await store.setString('${cacheKey}_v2', json.encode(map));
+  }
+}

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -9,15 +9,19 @@ extension ParseObjectOffline on ParseObject {
     final String cacheKey = 'offline_cache_$parseClassName';
     final Map<String, String> map = await _loadMap(store, cacheKey);
     if (objectId == null) {
-      print(
-        'ParseObjectOffline.saveToLocalCache: skipping object with no objectId '
-        'for $parseClassName',
-      );
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline.saveToLocalCache: skipping object with no objectId '
+          'for $parseClassName',
+        );
+      }
       return;
     }
     map[objectId!] = json.encode(toJson(full: true));
     await _saveMap(store, cacheKey, map);
-    print('ParseObjectOffline: saved $objectId to cache for $parseClassName');
+    if (isDebugEnabled()) {
+      print('ParseObjectOffline: saved $objectId to cache for $parseClassName');
+    }
   }
 
   /// Remove this object from local storage.
@@ -28,9 +32,11 @@ extension ParseObjectOffline on ParseObject {
     final Map<String, String> map = await _loadMap(store, cacheKey);
     if (map.remove(objectId) != null) {
       await _saveMap(store, cacheKey, map);
-      print(
-        'ParseObjectOffline: removed $objectId from cache for $parseClassName',
-      );
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline: removed $objectId from cache for $parseClassName',
+        );
+      }
     }
   }
 
@@ -50,12 +56,16 @@ extension ParseObjectOffline on ParseObject {
       obj.addAll(updates);
       map[objectId!] = json.encode(obj);
       await _saveMap(store, cacheKey, map);
-      print(
-        'ParseObjectOffline: updated $objectId in cache for $parseClassName',
-      );
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline: updated $objectId in cache for $parseClassName',
+        );
+      }
       return true;
     } catch (e) {
-      print('ParseObjectOffline.updateInLocalCache: error for $objectId: $e');
+      if (isDebugEnabled()) {
+        print('ParseObjectOffline.updateInLocalCache: error for $objectId: $e');
+      }
       return false;
     }
   }
@@ -79,10 +89,12 @@ extension ParseObjectOffline on ParseObject {
         className,
       ).fromJson(json.decode(raw) as Map<String, dynamic>);
     } catch (e) {
-      print(
-        'ParseObjectOffline.loadFromLocalCache: corrupt entry for $objectId '
-        'in $className — $e',
-      );
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline.loadFromLocalCache: corrupt entry for $objectId '
+          'in $className — $e',
+        );
+      }
       return null;
     }
   }
@@ -113,16 +125,20 @@ extension ParseObjectOffline on ParseObject {
           results.add(object);
         }
       } catch (e) {
-        print(
-          'ParseObjectOffline.loadAllFromLocalCache: skipping corrupt entry '
-          '${entry.key} for $className — $e',
-        );
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline.loadAllFromLocalCache: skipping corrupt entry '
+            '${entry.key} for $className — $e',
+          );
+        }
       }
     }
-    print(
-      'ParseObjectOffline: loaded ${results.length} objects from cache for '
-      '$className${where != null ? ' (filtered)' : ''}',
-    );
+    if (isDebugEnabled()) {
+      print(
+        'ParseObjectOffline: loaded ${results.length} objects from cache for '
+        '$className${where != null ? ' (filtered)' : ''}',
+      );
+    }
     return results;
   }
 
@@ -142,10 +158,12 @@ extension ParseObjectOffline on ParseObject {
     for (final obj in objects) {
       final id = obj.objectId;
       if (id == null) {
-        print(
-          'ParseObjectOffline.saveAllToLocalCache: skipping object without '
-          'objectId for $className',
-        );
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline.saveAllToLocalCache: skipping object without '
+            'objectId for $className',
+          );
+        }
         continue;
       }
       // Encode each object independently so one bad object (e.g. a value that
@@ -157,19 +175,23 @@ extension ParseObjectOffline on ParseObject {
         map[id] = encoded;
       } catch (e) {
         failed++;
-        print(
-          'ParseObjectOffline.saveAllToLocalCache: skipping object $id '
-          '(createdAt=${obj.createdAt?.toIso8601String()}) for '
-          '$className — encode failed: $e',
-        );
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline.saveAllToLocalCache: skipping object $id '
+            '(createdAt=${obj.createdAt?.toIso8601String()}) for '
+            '$className — encode failed: $e',
+          );
+        }
       }
     }
 
     await _saveMap(store, cacheKey, map);
-    print(
-      'ParseObjectOffline: batch saved to $className. '
-      'Added: $added, Updated: $updated, Failed: $failed, Total: ${map.length}',
-    );
+    if (isDebugEnabled()) {
+      print(
+        'ParseObjectOffline: batch saved to $className. '
+        'Added: $added, Updated: $updated, Failed: $failed, Total: ${map.length}',
+      );
+    }
   }
 
   /// Returns all cached objectIds for a class. O(1) — no JSON decoding.
@@ -206,7 +228,9 @@ extension ParseObjectOffline on ParseObject {
     // made this a silent no-op.
     await store.remove('${cacheKey}_v2');
     await store.remove(cacheKey);
-    print('ParseObjectOffline: cleared cache for $className');
+    if (isDebugEnabled()) {
+      print('ParseObjectOffline: cleared cache for $className');
+    }
   }
 
   /// Sync: pushes every cached object to the server.
@@ -230,16 +254,20 @@ extension ParseObjectOffline on ParseObject {
       if (response.success) {
         synced++;
       } else {
-        print(
-          'ParseObjectOffline.syncLocalCacheWithServer: failed to save '
-          '${obj.objectId} — ${response.error?.message}',
-        );
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline.syncLocalCacheWithServer: failed to save '
+            '${obj.objectId} — ${response.error?.message}',
+          );
+        }
       }
     }
-    print(
-      'ParseObjectOffline: sync complete for $className. '
-      'Synced: $synced, Skipped: $skipped',
-    );
+    if (isDebugEnabled()) {
+      print(
+        'ParseObjectOffline: sync complete for $className. '
+        'Synced: $synced, Skipped: $skipped',
+      );
+    }
   }
 
   // ─── Internal helpers ────────────────────────────────────────────────────
@@ -275,10 +303,12 @@ extension ParseObjectOffline on ParseObject {
       // Write migrated data in new format and remove old list.
       await store.setString('${cacheKey}_v2', json.encode(migrated));
       await store.remove(cacheKey);
-      print(
-        'ParseObjectOffline: migrated ${migrated.length} entries from list '
-        'format to map format for $cacheKey',
-      );
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline: migrated ${migrated.length} entries from list '
+          'format to map format for $cacheKey',
+        );
+      }
     }
     return migrated;
   }

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -84,6 +84,18 @@ String _offlineCacheKey(String className) {
   return 'offline_cache_${Uri.encodeComponent(namespace)}:$className';
 }
 
+/// Storage key holding the map-format cache for [cacheKey].
+///
+/// ':' for the same reason as the namespace boundary: with the old
+/// `'${cacheKey}_v2'` a class genuinely named `X_v2` produced
+/// `offline_cache_X_v2`, which is the live map key of class `X`, so
+/// `clearLocalCacheForClass('X_v2')` wiped class `X`.
+String _offlineMapKey(String cacheKey) => '$cacheKey:v2';
+
+/// The superseded `_v2` suffix, still read once so existing caches migrate
+/// rather than silently emptying.
+String _legacyOfflineMapKey(String cacheKey) => '${cacheKey}_v2';
+
 extension ParseObjectOffline on ParseObject {
   /// Namespace applied to every offline cache key, for separating the caches
   /// of different accounts in the same app.
@@ -340,10 +352,11 @@ extension ParseObjectOffline on ParseObject {
     final CoreStore store = ParseCoreData().getStore();
     final String cacheKey = _offlineCacheKey(className);
     await _withOfflineCacheLock(cacheKey, () async {
-      // Remove BOTH formats. Reads and writes go through the `_v2` map key, so
+      // Remove EVERY format. Reads and writes go through the map key, so
       // dropping only the legacy list key left the actual cache fully intact
       // and made this a silent no-op.
-      await store.remove('${cacheKey}_v2');
+      await store.remove(_offlineMapKey(cacheKey));
+      await store.remove(_legacyOfflineMapKey(cacheKey));
       await store.remove(cacheKey);
     });
     if (isDebugEnabled()) {
@@ -376,7 +389,15 @@ extension ParseObjectOffline on ParseObject {
     String className, {
     bool Function(ParseObject obj)? shouldSync,
   }) async {
-    final List<ParseObject> objects = await loadAllFromLocalCache(className);
+    // Loaded via fromJsonForManualObject, NOT fromJson. `fromJson` only fills
+    // the object data and records nothing as unsaved, so for an object that
+    // already has an objectId `save()` finds `_isDirty(false)` false, never
+    // calls `update()`, and returns the `_saveChildren` result — success, with
+    // no request sent. This method would then report every object as synced
+    // while writing nothing, which is precisely the failure ParseOfflineSyncResult
+    // exists to surface. The manual variant registers the fields as unsaved
+    // changes so the update actually goes out.
+    final List<ParseObject> objects = await _loadAllForSync(className);
     int synced = 0;
     int skipped = 0;
     final List<ParseOfflineSyncFailure> failures = <ParseOfflineSyncFailure>[];
@@ -413,6 +434,38 @@ extension ParseObjectOffline on ParseObject {
 
   // ─── Internal helpers ────────────────────────────────────────────────────
 
+  /// Like [loadAllFromLocalCache], but decodes with `fromJsonForManualObject`
+  /// so every cached field is registered as an unsaved change and a later
+  /// `save()` actually issues an update. Only used by
+  /// [syncLocalCacheWithServer]; normal reads must not mark objects dirty.
+  static Future<List<ParseObject>> _loadAllForSync(String className) async {
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = _offlineCacheKey(className);
+    final Map<String, String> map = await _withOfflineCacheLock(
+      cacheKey,
+      () => _loadMap(store, cacheKey),
+    );
+    final List<ParseObject> results = <ParseObject>[];
+    for (final entry in map.entries) {
+      try {
+        results.add(
+          ParseObject(className).fromJsonForManualObject(
+                json.decode(entry.value) as Map<String, dynamic>,
+              )
+              as ParseObject,
+        );
+      } catch (e) {
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline._loadAllForSync: skipping corrupt entry '
+            '${entry.key} for $className — $e',
+          );
+        }
+      }
+    }
+    return results;
+  }
+
   // The cache is stored as a single JSON-encoded Map<String, String> keyed by
   // objectId. This gives O(1) lookups and avoids scanning every entry for id
   // comparisons. The old format (List<String>) is migrated on first read.
@@ -423,12 +476,35 @@ extension ParseObjectOffline on ParseObject {
     CoreStore store,
     String cacheKey,
   ) async {
-    // Try new map format first.
-    final String? mapJson = await store.getString('${cacheKey}_v2');
+    // Try the current map key first.
+    final String? mapJson = await store.getString(_offlineMapKey(cacheKey));
     if (mapJson != null) {
       try {
         final decoded = json.decode(mapJson) as Map<String, dynamic>;
         return decoded.map((k, v) => MapEntry(k, v as String));
+      } catch (_) {}
+    }
+
+    // Then the superseded '_v2' suffix, moving it to the ':v2' key so this
+    // costs one read once rather than dropping an existing cache.
+    final String? legacyMapJson = await store.getString(
+      _legacyOfflineMapKey(cacheKey),
+    );
+    if (legacyMapJson != null) {
+      try {
+        final decoded = json.decode(legacyMapJson) as Map<String, dynamic>;
+        final Map<String, String> moved = decoded.map(
+          (k, v) => MapEntry(k, v as String),
+        );
+        await store.setString(_offlineMapKey(cacheKey), legacyMapJson);
+        await store.remove(_legacyOfflineMapKey(cacheKey));
+        if (isDebugEnabled()) {
+          print(
+            'ParseObjectOffline: moved ${moved.length} entries from the _v2 '
+            'key to the :v2 key for $cacheKey',
+          );
+        }
+        return moved;
       } catch (_) {}
     }
 
@@ -445,7 +521,7 @@ extension ParseObjectOffline on ParseObject {
     }
     if (migrated.isNotEmpty) {
       // Write migrated data in new format and remove old list.
-      await store.setString('${cacheKey}_v2', json.encode(migrated));
+      await store.setString(_offlineMapKey(cacheKey), json.encode(migrated));
       await store.remove(cacheKey);
       if (isDebugEnabled()) {
         print(
@@ -462,6 +538,6 @@ extension ParseObjectOffline on ParseObject {
     String cacheKey,
     Map<String, String> map,
   ) async {
-    await store.setString('${cacheKey}_v2', json.encode(map));
+    await store.setString(_offlineMapKey(cacheKey), json.encode(map));
   }
 }

--- a/packages/dart/lib/src/objects/parse_offline_object.dart
+++ b/packages/dart/lib/src/objects/parse_offline_object.dart
@@ -1,13 +1,100 @@
 part of '../../parse_server_sdk.dart';
 
+/// Outcome of [ParseObjectOffline.syncLocalCacheWithServer].
+///
+/// Exists so callers get a failure signal without having to read the log: a
+/// void return made an unsuccessful `save()` indistinguishable from a clean
+/// sync, and unsynced edits could be treated as persisted.
+class ParseOfflineSyncResult {
+  ParseOfflineSyncResult({
+    required this.synced,
+    required this.skipped,
+    required this.failures,
+  });
+
+  /// Objects successfully saved to the server.
+  final int synced;
+
+  /// Objects rejected by the `shouldSync` predicate.
+  final int skipped;
+
+  /// The objects whose `save()` did not succeed, with the reported error.
+  final List<ParseOfflineSyncFailure> failures;
+
+  /// True when at least one object failed to save.
+  bool get hasFailures => failures.isNotEmpty;
+
+  @override
+  String toString() =>
+      'ParseOfflineSyncResult(synced: $synced, skipped: $skipped, '
+      'failures: ${failures.length})';
+}
+
+/// A single failed save from [ParseObjectOffline.syncLocalCacheWithServer].
+class ParseOfflineSyncFailure {
+  ParseOfflineSyncFailure(this.object, this.error);
+
+  final ParseObject object;
+  final ParseError? error;
+
+  @override
+  String toString() =>
+      'ParseOfflineSyncFailure(${object.objectId}: ${error?.message})';
+}
+
+/// Serialises read-modify-write sequences per cache key.
+///
+/// Every mutating operation loads the whole map, edits it, then writes the
+/// whole map back. Without this, two concurrent calls both read the same
+/// starting state and the second write silently discards the first one's
+/// change. Reads take the lock too, because [_loadMap] itself writes when it
+/// migrates the legacy format.
+final Map<String, Future<void>> _offlineCacheLocks = <String, Future<void>>{};
+
+Future<R> _withOfflineCacheLock<R>(
+  String cacheKey,
+  Future<R> Function() action,
+) {
+  final Future<void> previous =
+      _offlineCacheLocks[cacheKey] ?? Future<void>.value();
+  final Completer<void> release = Completer<void>();
+  _offlineCacheLocks[cacheKey] = release.future;
+  return previous.then((_) => action()).whenComplete(() {
+    release.complete();
+    // Only drop the entry if nobody queued behind us, otherwise the next
+    // waiter would lose its place in the chain.
+    if (identical(_offlineCacheLocks[cacheKey], release.future)) {
+      _offlineCacheLocks.remove(cacheKey);
+    }
+  });
+}
+
+String _offlineCacheKey(String className) {
+  final String? namespace = ParseObjectOffline.cacheNamespace;
+  return namespace == null || namespace.isEmpty
+      ? 'offline_cache_$className'
+      : 'offline_cache_${namespace}_$className';
+}
+
 extension ParseObjectOffline on ParseObject {
+  /// Namespace applied to every offline cache key, for separating the caches
+  /// of different accounts in the same app.
+  ///
+  /// The cache is plain local storage and [loadFromLocalCache] reads it
+  /// directly, so it is NOT subject to the server's access checks. With a
+  /// persistent [CoreStore] and no namespace, objects cached by one user stay
+  /// readable after switching to another account.
+  ///
+  /// Set this to a stable per-account value (for example the user's objectId)
+  /// on login, and call [clearLocalCacheForNamespace] on logout if the cached
+  /// data should not outlive the session. Leave it null for single-account
+  /// apps, which keeps the historic key layout.
+  static String? cacheNamespace;
+
   // ─── Single-object operations ────────────────────────────────────────────
 
   /// Save this object to local storage for offline access.
   Future<void> saveToLocalCache() async {
-    final CoreStore store = ParseCoreData().getStore();
-    final String cacheKey = 'offline_cache_$parseClassName';
-    final Map<String, String> map = await _loadMap(store, cacheKey);
     if (objectId == null) {
       if (isDebugEnabled()) {
         print(
@@ -17,10 +104,17 @@ extension ParseObjectOffline on ParseObject {
       }
       return;
     }
-    map[objectId!] = json.encode(toJson(full: true));
-    await _saveMap(store, cacheKey, map);
+    final CoreStore store = ParseCoreData().getStore();
+    final String cacheKey = _offlineCacheKey(parseClassName);
+    final String id = objectId!;
+    final String encoded = json.encode(toJson(full: true));
+    await _withOfflineCacheLock(cacheKey, () async {
+      final Map<String, String> map = await _loadMap(store, cacheKey);
+      map[id] = encoded;
+      await _saveMap(store, cacheKey, map);
+    });
     if (isDebugEnabled()) {
-      print('ParseObjectOffline: saved $objectId to cache for $parseClassName');
+      print('ParseObjectOffline: saved $id to cache for $parseClassName');
     }
   }
 
@@ -28,15 +122,16 @@ extension ParseObjectOffline on ParseObject {
   Future<void> removeFromLocalCache() async {
     if (objectId == null) return;
     final CoreStore store = ParseCoreData().getStore();
-    final String cacheKey = 'offline_cache_$parseClassName';
-    final Map<String, String> map = await _loadMap(store, cacheKey);
-    if (map.remove(objectId) != null) {
+    final String cacheKey = _offlineCacheKey(parseClassName);
+    final String id = objectId!;
+    final bool removed = await _withOfflineCacheLock(cacheKey, () async {
+      final Map<String, String> map = await _loadMap(store, cacheKey);
+      if (map.remove(id) == null) return false;
       await _saveMap(store, cacheKey, map);
-      if (isDebugEnabled()) {
-        print(
-          'ParseObjectOffline: removed $objectId from cache for $parseClassName',
-        );
-      }
+      return true;
+    });
+    if (removed && isDebugEnabled()) {
+      print('ParseObjectOffline: removed $id from cache for $parseClassName');
     }
   }
 
@@ -46,28 +141,29 @@ extension ParseObjectOffline on ParseObject {
   Future<bool> updateInLocalCache(Map<String, dynamic> updates) async {
     if (objectId == null) return false;
     final CoreStore store = ParseCoreData().getStore();
-    final String cacheKey = 'offline_cache_$parseClassName';
-    final Map<String, String> map = await _loadMap(store, cacheKey);
-    final String? existing = map[objectId];
-    if (existing == null) return false;
-    try {
-      final Map<String, dynamic> obj =
-          json.decode(existing) as Map<String, dynamic>;
-      obj.addAll(updates);
-      map[objectId!] = json.encode(obj);
-      await _saveMap(store, cacheKey, map);
-      if (isDebugEnabled()) {
-        print(
-          'ParseObjectOffline: updated $objectId in cache for $parseClassName',
-        );
+    final String cacheKey = _offlineCacheKey(parseClassName);
+    final String id = objectId!;
+    return _withOfflineCacheLock(cacheKey, () async {
+      final Map<String, String> map = await _loadMap(store, cacheKey);
+      final String? existing = map[id];
+      if (existing == null) return false;
+      try {
+        final Map<String, dynamic> obj =
+            json.decode(existing) as Map<String, dynamic>;
+        obj.addAll(updates);
+        map[id] = json.encode(obj);
+        await _saveMap(store, cacheKey, map);
+        if (isDebugEnabled()) {
+          print('ParseObjectOffline: updated $id in cache for $parseClassName');
+        }
+        return true;
+      } catch (e) {
+        if (isDebugEnabled()) {
+          print('ParseObjectOffline.updateInLocalCache: error for $id: $e');
+        }
+        return false;
       }
-      return true;
-    } catch (e) {
-      if (isDebugEnabled()) {
-        print('ParseObjectOffline.updateInLocalCache: error for $objectId: $e');
-      }
-      return false;
-    }
+    });
   }
 
   // ─── Batch / static operations ───────────────────────────────────────────
@@ -78,11 +174,11 @@ extension ParseObjectOffline on ParseObject {
     String objectId,
   ) async {
     final CoreStore store = ParseCoreData().getStore();
-    final Map<String, String> map = await _loadMap(
-      store,
-      'offline_cache_$className',
-    );
-    final String? raw = map[objectId];
+    final String cacheKey = _offlineCacheKey(className);
+    final String? raw = await _withOfflineCacheLock(cacheKey, () async {
+      final Map<String, String> map = await _loadMap(store, cacheKey);
+      return map[objectId];
+    });
     if (raw == null) return null;
     try {
       return ParseObject(
@@ -99,7 +195,6 @@ extension ParseObjectOffline on ParseObject {
     }
   }
 
-  /// Load all objects of a class from local storage.
   /// Load every cached object of [className].
   ///
   /// The offline store holds one bucket per class, so callers that only want a
@@ -111,9 +206,10 @@ extension ParseObjectOffline on ParseObject {
     bool Function(ParseObject object)? where,
   }) async {
     final CoreStore store = ParseCoreData().getStore();
-    final Map<String, String> map = await _loadMap(
-      store,
-      'offline_cache_$className',
+    final String cacheKey = _offlineCacheKey(className);
+    final Map<String, String> map = await _withOfflineCacheLock(
+      cacheKey,
+      () => _loadMap(store, cacheKey),
     );
     final List<ParseObject> results = [];
     for (final entry in map.entries) {
@@ -149,49 +245,52 @@ extension ParseObjectOffline on ParseObject {
   ) async {
     if (objects.isEmpty) return;
     final CoreStore store = ParseCoreData().getStore();
-    final String cacheKey = 'offline_cache_$className';
-    final Map<String, String> map = await _loadMap(store, cacheKey);
+    final String cacheKey = _offlineCacheKey(className);
 
-    int added = 0;
-    int updated = 0;
-    int failed = 0;
-    for (final obj in objects) {
-      final id = obj.objectId;
-      if (id == null) {
-        if (isDebugEnabled()) {
-          print(
-            'ParseObjectOffline.saveAllToLocalCache: skipping object without '
-            'objectId for $className',
-          );
+    await _withOfflineCacheLock(cacheKey, () async {
+      final Map<String, String> map = await _loadMap(store, cacheKey);
+      int added = 0;
+      int updated = 0;
+      int failed = 0;
+      for (final obj in objects) {
+        final id = obj.objectId;
+        if (id == null) {
+          if (isDebugEnabled()) {
+            print(
+              'ParseObjectOffline.saveAllToLocalCache: skipping object without '
+              'objectId for $className',
+            );
+          }
+          continue;
         }
-        continue;
-      }
-      // Encode each object independently so one bad object (e.g. a value that
-      // fails to serialize) can't abort the whole batch and prevent every other
-      // item — including a freshly-added one — from being cached.
-      try {
-        final encoded = json.encode(obj.toJson(full: true));
-        map.containsKey(id) ? updated++ : added++;
-        map[id] = encoded;
-      } catch (e) {
-        failed++;
-        if (isDebugEnabled()) {
-          print(
-            'ParseObjectOffline.saveAllToLocalCache: skipping object $id '
-            '(createdAt=${obj.createdAt?.toIso8601String()}) for '
-            '$className — encode failed: $e',
-          );
+        // Encode each object independently so one bad object (e.g. a value that
+        // fails to serialize) can't abort the whole batch and prevent every other
+        // item — including a freshly-added one — from being cached.
+        try {
+          final encoded = json.encode(obj.toJson(full: true));
+          map.containsKey(id) ? updated++ : added++;
+          map[id] = encoded;
+        } catch (e) {
+          failed++;
+          if (isDebugEnabled()) {
+            print(
+              'ParseObjectOffline.saveAllToLocalCache: skipping object $id '
+              '(createdAt=${obj.createdAt?.toIso8601String()}) for '
+              '$className — encode failed: $e',
+            );
+          }
         }
       }
-    }
 
-    await _saveMap(store, cacheKey, map);
-    if (isDebugEnabled()) {
-      print(
-        'ParseObjectOffline: batch saved to $className. '
-        'Added: $added, Updated: $updated, Failed: $failed, Total: ${map.length}',
-      );
-    }
+      await _saveMap(store, cacheKey, map);
+      if (isDebugEnabled()) {
+        print(
+          'ParseObjectOffline: batch saved to $className. '
+          'Added: $added, Updated: $updated, Failed: $failed, '
+          'Total: ${map.length}',
+        );
+      }
+    });
   }
 
   /// Returns all cached objectIds for a class. O(1) — no JSON decoding.
@@ -199,9 +298,10 @@ extension ParseObjectOffline on ParseObject {
     String className,
   ) async {
     final CoreStore store = ParseCoreData().getStore();
-    final Map<String, String> map = await _loadMap(
-      store,
-      'offline_cache_$className',
+    final String cacheKey = _offlineCacheKey(className);
+    final Map<String, String> map = await _withOfflineCacheLock(
+      cacheKey,
+      () => _loadMap(store, cacheKey),
     );
     return map.keys.toList();
   }
@@ -212,39 +312,59 @@ extension ParseObjectOffline on ParseObject {
     String objectId,
   ) async {
     final CoreStore store = ParseCoreData().getStore();
-    final Map<String, String> map = await _loadMap(
-      store,
-      'offline_cache_$className',
+    final String cacheKey = _offlineCacheKey(className);
+    final Map<String, String> map = await _withOfflineCacheLock(
+      cacheKey,
+      () => _loadMap(store, cacheKey),
     );
     return map.containsKey(objectId);
   }
 
-  /// Wipes the entire cache for a class.
+  /// Wipes the entire cache for a class, in the current [cacheNamespace].
   static Future<void> clearLocalCacheForClass(String className) async {
     final CoreStore store = ParseCoreData().getStore();
-    final String cacheKey = 'offline_cache_$className';
-    // Remove BOTH formats. Reads and writes go through the `_v2` map key, so
-    // dropping only the legacy list key left the actual cache fully intact and
-    // made this a silent no-op.
-    await store.remove('${cacheKey}_v2');
-    await store.remove(cacheKey);
+    final String cacheKey = _offlineCacheKey(className);
+    await _withOfflineCacheLock(cacheKey, () async {
+      // Remove BOTH formats. Reads and writes go through the `_v2` map key, so
+      // dropping only the legacy list key left the actual cache fully intact
+      // and made this a silent no-op.
+      await store.remove('${cacheKey}_v2');
+      await store.remove(cacheKey);
+    });
     if (isDebugEnabled()) {
       print('ParseObjectOffline: cleared cache for $className');
     }
   }
 
-  /// Sync: pushes every cached object to the server.
+  /// Wipes the cache of every [classNames] entry for the current
+  /// [cacheNamespace]. Call this on logout when cached data should not outlive
+  /// the session.
+  ///
+  /// The store has no key enumeration, so the classes to clear must be named.
+  static Future<void> clearLocalCacheForNamespace(
+    List<String> classNames,
+  ) async {
+    for (final String className in classNames) {
+      await clearLocalCacheForClass(className);
+    }
+  }
+
+  /// Pushes every cached object of [className] to the server.
   ///
   /// Only call this when you know the local copy is authoritative (e.g. after
   /// collecting edits while offline). Objects whose server version may be newer
   /// should be reconciled before calling this.
-  static Future<void> syncLocalCacheWithServer(
+  ///
+  /// Returns a [ParseOfflineSyncResult]; check [ParseOfflineSyncResult.hasFailures]
+  /// before treating the local edits as persisted.
+  static Future<ParseOfflineSyncResult> syncLocalCacheWithServer(
     String className, {
     bool Function(ParseObject obj)? shouldSync,
   }) async {
     final List<ParseObject> objects = await loadAllFromLocalCache(className);
     int synced = 0;
     int skipped = 0;
+    final List<ParseOfflineSyncFailure> failures = <ParseOfflineSyncFailure>[];
     for (final obj in objects) {
       if (shouldSync != null && !shouldSync(obj)) {
         skipped++;
@@ -254,6 +374,7 @@ extension ParseObjectOffline on ParseObject {
       if (response.success) {
         synced++;
       } else {
+        failures.add(ParseOfflineSyncFailure(obj, response.error));
         if (isDebugEnabled()) {
           print(
             'ParseObjectOffline.syncLocalCacheWithServer: failed to save '
@@ -265,9 +386,14 @@ extension ParseObjectOffline on ParseObject {
     if (isDebugEnabled()) {
       print(
         'ParseObjectOffline: sync complete for $className. '
-        'Synced: $synced, Skipped: $skipped',
+        'Synced: $synced, Skipped: $skipped, Failed: ${failures.length}',
       );
     }
+    return ParseOfflineSyncResult(
+      synced: synced,
+      skipped: skipped,
+      failures: failures,
+    );
   }
 
   // ─── Internal helpers ────────────────────────────────────────────────────
@@ -275,6 +401,9 @@ extension ParseObjectOffline on ParseObject {
   // The cache is stored as a single JSON-encoded Map<String, String> keyed by
   // objectId. This gives O(1) lookups and avoids scanning every entry for id
   // comparisons. The old format (List<String>) is migrated on first read.
+  //
+  // Callers must hold the key's lock via _withOfflineCacheLock: the migration
+  // branch writes.
   static Future<Map<String, String>> _loadMap(
     CoreStore store,
     String cacheKey,

--- a/packages/dart/lib/src/storage/core_store_memory.dart
+++ b/packages/dart/lib/src/storage/core_store_memory.dart
@@ -40,7 +40,13 @@ class CoreStoreMemoryImp implements CoreStore {
 
   @override
   Future<List<String>?> getStringList(String key) async {
-    return _data[key];
+    final value = _data[key];
+    if (value == null) return null;
+    if (value is List<String>) return value;
+    // A list that round-tripped through JSON comes back as List<dynamic>, so
+    // returning _data[key] directly threw a CastError instead of the list.
+    if (value is Iterable) return value.map((e) => e.toString()).toList();
+    return null;
   }
 
   @override

--- a/packages/dart/lib/src/storage/core_store_memory.dart
+++ b/packages/dart/lib/src/storage/core_store_memory.dart
@@ -42,7 +42,9 @@ class CoreStoreMemoryImp implements CoreStore {
   Future<List<String>?> getStringList(String key) async {
     final value = _data[key];
     if (value == null) return null;
-    if (value is List<String>) return value;
+    // Copy, so a caller mutating the result cannot reach into the store. The
+    // backing map is static, so that mutation would be process-wide.
+    if (value is List<String>) return List<String>.of(value);
     // A list that round-tripped through JSON comes back as List<dynamic>, so
     // returning _data[key] directly threw a CastError instead of the list.
     if (value is Iterable) return value.map((e) => e.toString()).toList();

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -100,7 +100,8 @@ class CoreStoreSembastImp implements CoreStore {
   Future<List<String>?> getStringList(String key) async {
     final value = await get(key);
     if (value == null) return null;
-    if (value is List<String>) return value;
+    // Copy, so a caller mutating the result cannot reach into the store.
+    if (value is List<String>) return List<String>.of(value);
     // Sembast hands back List<dynamic> for anything it decoded from disk, so
     // the previous `await get(key)` as List<String> threw a CastError on every
     // list that had survived a restart.

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -96,8 +96,14 @@ class CoreStoreSembastImp implements CoreStore {
 
   @override
   Future<List<String>?> getStringList(String key) async {
-    final List<String>? storedItem = await get(key);
-    return storedItem;
+    final value = await get(key);
+    if (value == null) return null;
+    if (value is List<String>) return value;
+    // Sembast hands back List<dynamic> for anything it decoded from disk, so
+    // the previous `await get(key)` as List<String> threw a CastError on every
+    // list that had survived a restart.
+    if (value is Iterable) return value.map((e) => e.toString()).toList();
+    return null;
   }
 
   @override

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -56,8 +56,10 @@ class CoreStoreSembastImp implements CoreStore {
   final StoreRef<String, dynamic> _store;
 
   @override
-  Future<bool> clear() {
-    return _store.drop(_database) as Future<bool>;
+  Future<void> clear() {
+    // `drop` returns Future<void>; the old `as Future<bool>` was an
+    // unconditional CastError, so clearing the Sembast store always threw.
+    return _store.drop(_database);
   }
 
   @override

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -1090,12 +1090,19 @@ class ParseLiveListElementSnapshot<T extends ParseObject> {
     this.loadedData,
     this.error,
     this.preLoadedData,
+    this.isOptimistic = false,
   });
 
   final T? loadedData;
   final T? preLoadedData;
 
   final ParseError? error;
+
+  /// True when this element is a caller-supplied optimistic (pending) item that
+  /// has not yet been confirmed by the server. Consumers can use this in their
+  /// childBuilder to style the row differently (e.g. dim it or show a spinner)
+  /// until the real object arrives and supersedes it.
+  final bool isOptimistic;
 
   bool get hasData => loadedData != null;
 

--- a/packages/dart/lib/src/utils/parse_live_list.dart
+++ b/packages/dart/lib/src/utils/parse_live_list.dart
@@ -1,6 +1,23 @@
 part of '../../parse_server_sdk.dart';
 
 // ignore_for_file: invalid_use_of_protected_member
+
+/// Reads [key] off [object] as a single sub-item pointer, or null when the
+/// field isn't one.
+///
+/// The live-list include/subscribe machinery derives its watch list from the
+/// query's `include`, which can legitimately name an ARRAY of pointers
+/// (likeUsers, viewUsers, buddies, …) or a relation. That machinery handles
+/// one object at a time, and `get<ParseObject>` ends in an unguarded `as`
+/// which throws `type 'List<dynamic>' is not a subtype of type 'ParseObject?'`
+/// for those fields — an unhandled async error on every list update, which
+/// also silently kills include-loading and sub-item subscriptions for the row.
+/// Skip anything that isn't a single ParseObject rather than crashing.
+ParseObject? _subItemOrNull(ParseObject object, String key) {
+  final dynamic value = object.get<dynamic>(key);
+  return value is ParseObject ? value : null;
+}
+
 class ParseLiveList<T extends ParseObject> {
   ParseLiveList._(
     this._query,
@@ -337,12 +354,14 @@ class ParseLiveList<T extends ParseObject> {
 
     for (String key in paths.keys) {
       if (object.containsKey(key)) {
-        ParseObject? includedObject = object.get<ParseObject>(key);
+        ParseObject? includedObject = _subItemOrNull(object, key);
         if (includedObject != null) {
           //If the object is not fetched
           if (!includedObject.containsKey(keyVarUpdatedAt)) {
             //See if oldObject contains key
-            ParseObject? keyInOld = oldObject?.get<ParseObject>(key);
+            ParseObject? keyInOld = oldObject == null
+                ? null
+                : _subItemOrNull(oldObject, key);
             if (keyInOld != null) {
               //If the object is not fetched || the ids don't match / the pointer changed
               if (!keyInOld.containsKey(keyVarUpdatedAt) ||
@@ -857,7 +876,7 @@ class ParseLiveListElement<T extends ParseObject> {
             _subscribeSubItem(
               object,
               key,
-              object.get<ParseObject>(key.key),
+              _subItemOrNull(object, key.key),
               _updatedSubItems[key],
             ),
           );
@@ -893,7 +912,7 @@ class ParseLiveListElement<T extends ParseObject> {
           _subscribeSubItem(
             subObject,
             key,
-            subObject.get<ParseObject>(key.key),
+            _subItemOrNull(subObject, key.key),
             path[key],
           ),
         );
@@ -926,7 +945,7 @@ class ParseLiveListElement<T extends ParseObject> {
                     _subscribeSubItem(
                       newObject,
                       key,
-                      newObject.get<ParseObject>(key.key),
+                      _subItemOrNull(newObject, key.key),
                       path[key],
                     ),
                   );
@@ -990,7 +1009,7 @@ class ParseLiveListElement<T extends ParseObject> {
   ) async {
     final List<Future<void>> tasks = <Future<void>>[];
     for (PathKey key in path.keys) {
-      ParseObject? subObject = root.get<ParseObject>(key.key);
+      ParseObject? subObject = _subItemOrNull(root, key.key);
       if (subObject != null) {
         if (subObject.containsKey(keyVarUpdatedAt) == true) {
           final QueryBuilder<ParseObject> queryBuilder =

--- a/packages/dart/test/src/objects/parse_offline_object_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_object_test.dart
@@ -1,0 +1,345 @@
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeParse();
+  });
+
+  group('ParseObjectOffline Extension', () {
+    const testClassName = 'TestOfflineClass';
+
+    setUp(() async {
+      // Clear cache before each test
+      await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+    });
+
+    tearDown(() async {
+      // Clean up after each test
+      await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+    });
+
+    group('saveToLocalCache', () {
+      test('should save object to local cache', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'test123'
+          ..set('name', 'Test Object')
+          ..set('value', 42);
+
+        // Act
+        await obj.saveToLocalCache();
+
+        // Assert
+        final exists = await ParseObjectOffline.existsInLocalCache(
+          testClassName,
+          'test123',
+        );
+        expect(exists, isTrue);
+      });
+
+      test('should update existing object in cache', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'test123'
+          ..set('name', 'Original Name');
+
+        await obj.saveToLocalCache();
+
+        // Act - Update the object
+        obj.set('name', 'Updated Name');
+        await obj.saveToLocalCache();
+
+        // Assert
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'test123',
+        );
+        expect(loaded, isNotNull);
+        expect(loaded!.get<String>('name'), equals('Updated Name'));
+      });
+    });
+
+    group('loadFromLocalCache', () {
+      test('should load object from local cache', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'load123'
+          ..set('name', 'Load Test')
+          ..set('count', 100);
+
+        await obj.saveToLocalCache();
+
+        // Act
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'load123',
+        );
+
+        // Assert
+        expect(loaded, isNotNull);
+        expect(loaded!.objectId, equals('load123'));
+        expect(loaded.get<String>('name'), equals('Load Test'));
+        expect(loaded.get<int>('count'), equals(100));
+      });
+
+      test('should return null for non-existent object', () async {
+        // Act
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'nonexistent',
+        );
+
+        // Assert
+        expect(loaded, isNull);
+      });
+    });
+
+    group('saveAllToLocalCache', () {
+      test('should save multiple objects to cache', () async {
+        // Arrange
+        final objects = List.generate(5, (i) {
+          return ParseObject(testClassName)
+            ..objectId = 'batch$i'
+            ..set('index', i);
+        });
+
+        // Act
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, objects);
+
+        // Assert
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(5));
+        for (int i = 0; i < 5; i++) {
+          expect(ids.contains('batch$i'), isTrue);
+        }
+      });
+
+      test('should update existing and add new objects in batch', () async {
+        // Arrange - Save initial objects
+        final initialObjects = [
+          ParseObject(testClassName)
+            ..objectId = 'obj1'
+            ..set('value', 'initial1'),
+          ParseObject(testClassName)
+            ..objectId = 'obj2'
+            ..set('value', 'initial2'),
+        ];
+        await ParseObjectOffline.saveAllToLocalCache(
+          testClassName,
+          initialObjects,
+        );
+
+        // Act - Update one and add new
+        final updateObjects = [
+          ParseObject(testClassName)
+            ..objectId = 'obj1'
+            ..set('value', 'updated1'),
+          ParseObject(testClassName)
+            ..objectId = 'obj3'
+            ..set('value', 'new3'),
+        ];
+        await ParseObjectOffline.saveAllToLocalCache(
+          testClassName,
+          updateObjects,
+        );
+
+        // Assert
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(3)); // obj1, obj2, obj3
+
+        final updated = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'obj1',
+        );
+        expect(updated!.get<String>('value'), equals('updated1'));
+      });
+
+      test('should skip objects without objectId', () async {
+        // Arrange
+        final objects = [
+          ParseObject(testClassName)
+            ..objectId = 'valid1'
+            ..set('value', 1),
+          ParseObject(testClassName)..set('value', 2), // No objectId
+        ];
+
+        // Act
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, objects);
+
+        // Assert
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(1));
+        expect(ids.first, equals('valid1'));
+      });
+    });
+
+    group('loadAllFromLocalCache', () {
+      test('should load all objects from cache', () async {
+        // Arrange
+        final objects = List.generate(3, (i) {
+          return ParseObject(testClassName)
+            ..objectId = 'all$i'
+            ..set('index', i);
+        });
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, objects);
+
+        // Act
+        final loaded = await ParseObjectOffline.loadAllFromLocalCache(
+          testClassName,
+        );
+
+        // Assert
+        expect(loaded.length, equals(3));
+      });
+
+      test('should return empty list for empty cache', () async {
+        // Act
+        final loaded = await ParseObjectOffline.loadAllFromLocalCache(
+          'EmptyClass',
+        );
+
+        // Assert
+        expect(loaded, isEmpty);
+      });
+    });
+
+    group('removeFromLocalCache', () {
+      test('should remove object from cache', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'remove123'
+          ..set('name', 'To Remove');
+        await obj.saveToLocalCache();
+
+        // Act
+        await obj.removeFromLocalCache();
+
+        // Assert
+        final exists = await ParseObjectOffline.existsInLocalCache(
+          testClassName,
+          'remove123',
+        );
+        expect(exists, isFalse);
+      });
+    });
+
+    group('updateInLocalCache', () {
+      test('should update specific fields in cached object', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'update123'
+          ..set('name', 'Original')
+          ..set('count', 1);
+        await obj.saveToLocalCache();
+
+        // Act
+        await obj.updateInLocalCache({'name': 'Modified', 'count': 99});
+
+        // Assert
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'update123',
+        );
+        expect(loaded!.get<String>('name'), equals('Modified'));
+        expect(loaded.get<int>('count'), equals(99));
+      });
+    });
+
+    group('existsInLocalCache', () {
+      test('should return true for existing object', () async {
+        // Arrange
+        final obj = ParseObject(testClassName)
+          ..objectId = 'exists123'
+          ..set('name', 'Exists');
+        await obj.saveToLocalCache();
+
+        // Act
+        final exists = await ParseObjectOffline.existsInLocalCache(
+          testClassName,
+          'exists123',
+        );
+
+        // Assert
+        expect(exists, isTrue);
+      });
+
+      test('should return false for non-existing object', () async {
+        // Act
+        final exists = await ParseObjectOffline.existsInLocalCache(
+          testClassName,
+          'nonexistent',
+        );
+
+        // Assert
+        expect(exists, isFalse);
+      });
+    });
+
+    group('clearLocalCacheForClass', () {
+      test('should clear all objects for a class', () async {
+        // Arrange
+        final objects = List.generate(5, (i) {
+          return ParseObject(testClassName)
+            ..objectId = 'clear$i'
+            ..set('index', i);
+        });
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, objects);
+
+        // Act
+        await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+
+        // Assert
+        final loaded = await ParseObjectOffline.loadAllFromLocalCache(
+          testClassName,
+        );
+        expect(loaded, isEmpty);
+      });
+    });
+
+    group('getAllObjectIdsInLocalCache', () {
+      test('should return all object IDs', () async {
+        // Arrange
+        final objects = [
+          ParseObject(testClassName)
+            ..objectId = 'id1'
+            ..set('v', 1),
+          ParseObject(testClassName)
+            ..objectId = 'id2'
+            ..set('v', 2),
+          ParseObject(testClassName)
+            ..objectId = 'id3'
+            ..set('v', 3),
+        ];
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, objects);
+
+        // Act
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+
+        // Assert
+        expect(ids.length, equals(3));
+        expect(ids, containsAll(['id1', 'id2', 'id3']));
+      });
+
+      test('should return empty list for empty cache', () async {
+        // Act
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          'EmptyClass',
+        );
+
+        // Assert
+        expect(ids, isEmpty);
+      });
+    });
+  });
+}

--- a/packages/dart/test/src/objects/parse_offline_object_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_object_test.dart
@@ -341,5 +341,168 @@ void main() {
         expect(ids, isEmpty);
       });
     });
+
+    group('legacy format migration', () {
+      test('migrates a List<String> cache and drops the legacy key', () async {
+        // Arrange: seed the pre-map format directly under the legacy key.
+        final store = ParseCoreData().getStore();
+        const legacyKey = 'offline_cache_$testClassName';
+        await store.setStringList(legacyKey, <String>[
+          '{"className":"$testClassName","objectId":"legacy1","name":"One"}',
+          '{"className":"$testClassName","objectId":"legacy2","name":"Two"}',
+        ]);
+
+        // Act
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'legacy1',
+        );
+
+        // Assert: the object survives the migration...
+        expect(loaded, isNotNull);
+        expect(loaded!.objectId, equals('legacy1'));
+        expect(loaded.get<String>('name'), equals('One'));
+
+        // ...the rest of the bucket came across too...
+        final all = await ParseObjectOffline.loadAllFromLocalCache(
+          testClassName,
+        );
+        expect(all.length, equals(2));
+
+        // ...and the legacy key is gone, so it migrates exactly once.
+        expect(await store.getStringList(legacyKey), isNull);
+        expect(await store.getString('${legacyKey}_v2'), isNotNull);
+      });
+    });
+
+    group('concurrent mutations', () {
+      test('concurrent saves of different ids all survive', () async {
+        // Every mutation is a read-modify-write of one map. Without
+        // per-key serialisation these interleave and the last writer wins,
+        // silently dropping the others.
+        final objects = List.generate(20, (i) {
+          return ParseObject(testClassName)
+            ..objectId = 'concurrent$i'
+            ..set('index', i);
+        });
+
+        // Act: fire them all off without awaiting in between.
+        await Future.wait(objects.map((o) => o.saveToLocalCache()));
+
+        // Assert
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(20));
+        for (var i = 0; i < 20; i++) {
+          expect(ids, contains('concurrent$i'));
+        }
+      });
+
+      test('concurrent batch saves do not clobber each other', () async {
+        List<ParseObject> batch(String prefix) => List.generate(10, (i) {
+          return ParseObject(testClassName)
+            ..objectId = '$prefix$i'
+            ..set('index', i);
+        });
+
+        await Future.wait([
+          ParseObjectOffline.saveAllToLocalCache(testClassName, batch('a')),
+          ParseObjectOffline.saveAllToLocalCache(testClassName, batch('b')),
+          ParseObjectOffline.saveAllToLocalCache(testClassName, batch('c')),
+        ]);
+
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(30));
+      });
+
+      test('concurrent save and remove leave a consistent cache', () async {
+        final keep = List.generate(10, (i) {
+          return ParseObject(testClassName)
+            ..objectId = 'keep$i'
+            ..set('index', i);
+        });
+        final doomed = ParseObject(testClassName)
+          ..objectId = 'doomed'
+          ..set('index', -1);
+        await ParseObjectOffline.saveAllToLocalCache(testClassName, [doomed]);
+
+        await Future.wait(<Future<void>>[
+          ...keep.map((o) => o.saveToLocalCache()),
+          doomed.removeFromLocalCache(),
+        ]);
+
+        final ids = await ParseObjectOffline.getAllObjectIdsInLocalCache(
+          testClassName,
+        );
+        expect(ids.length, equals(10));
+        expect(ids, isNot(contains('doomed')));
+      });
+    });
+
+    group('cacheNamespace', () {
+      tearDown(() async {
+        await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+        ParseObjectOffline.cacheNamespace = null;
+        await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+      });
+
+      test('separates the caches of two accounts', () async {
+        // Account A caches an object.
+        ParseObjectOffline.cacheNamespace = 'userA';
+        await (ParseObject(testClassName)
+              ..objectId = 'secretOfA'
+              ..set('name', 'A only'))
+            .saveToLocalCache();
+
+        // Switching account must not expose it.
+        ParseObjectOffline.cacheNamespace = 'userB';
+        expect(
+          await ParseObjectOffline.loadFromLocalCache(
+            testClassName,
+            'secretOfA',
+          ),
+          isNull,
+        );
+        expect(
+          await ParseObjectOffline.loadAllFromLocalCache(testClassName),
+          isEmpty,
+        );
+
+        // Switching back restores it.
+        ParseObjectOffline.cacheNamespace = 'userA';
+        final back = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'secretOfA',
+        );
+        expect(back, isNotNull);
+        expect(back!.get<String>('name'), equals('A only'));
+
+        // Clearing one namespace leaves the other alone.
+        ParseObjectOffline.cacheNamespace = 'userB';
+        await (ParseObject(testClassName)..objectId = 'ofB').saveToLocalCache();
+        await ParseObjectOffline.clearLocalCacheForNamespace([testClassName]);
+        ParseObjectOffline.cacheNamespace = 'userA';
+        expect(
+          await ParseObjectOffline.loadAllFromLocalCache(testClassName),
+          hasLength(1),
+        );
+        await ParseObjectOffline.clearLocalCacheForClass(testClassName);
+      });
+
+      test('null namespace keeps the historic key layout', () async {
+        ParseObjectOffline.cacheNamespace = null;
+        await (ParseObject(
+          testClassName,
+        )..objectId = 'plain').saveToLocalCache();
+        final store = ParseCoreData().getStore();
+        expect(
+          await store.getString('offline_cache_${testClassName}_v2'),
+          isNotNull,
+        );
+      });
+    });
   });
 }

--- a/packages/dart/test/src/objects/parse_offline_object_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_object_test.dart
@@ -363,6 +363,35 @@ void main() {
         await ParseObjectOffline.clearLocalCacheForClass('X');
       });
 
+      test(
+        'clearing class X_v2 does not destroy class X before it migrates',
+        () async {
+          // offline_cache_X_v2 is BOTH the raw list-format key of class 'X_v2'
+          // and the unmigrated map key of class 'X'. Clearing X_v2 must not
+          // take X's cache with it.
+          final store = ParseCoreData().getStore();
+          await store.setString(
+            'offline_cache_X_v2',
+            '{"xOnly":"{\\"className\\":\\"X\\",'
+                '\\"objectId\\":\\"xOnly\\",\\"name\\":\\"Belongs to X\\"}"}',
+          );
+
+          await ParseObjectOffline.clearLocalCacheForClass('X_v2');
+
+          final survived = await ParseObjectOffline.loadFromLocalCache(
+            'X',
+            'xOnly',
+          );
+          expect(
+            survived,
+            isNotNull,
+            reason: "clearing X_v2 must not delete class X's unmigrated cache",
+          );
+          expect(survived!.get<String>('name'), equals('Belongs to X'));
+          await ParseObjectOffline.clearLocalCacheForClass('X');
+        },
+      );
+
       test('an existing _v2 cache is moved to the new key', () async {
         final store = ParseCoreData().getStore();
         const base = 'offline_cache_$testClassName';

--- a/packages/dart/test/src/objects/parse_offline_object_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_object_test.dart
@@ -342,6 +342,49 @@ void main() {
       });
     });
 
+    group('map key versioning', () {
+      test('a class named X_v2 does not collide with class X', () async {
+        // The map key used to be '${cacheKey}_v2', so class 'X_v2' produced
+        // offline_cache_X_v2 — the live map key of class 'X'. Clearing one
+        // therefore wiped the other.
+        await (ParseObject('X')..objectId = 'belongsToX').saveToLocalCache();
+        await (ParseObject(
+          'X_v2',
+        )..objectId = 'belongsToXv2').saveToLocalCache();
+
+        await ParseObjectOffline.clearLocalCacheForClass('X_v2');
+
+        final survivors = await ParseObjectOffline.loadAllFromLocalCache('X');
+        expect(
+          survivors.map((o) => o.objectId),
+          equals(['belongsToX']),
+          reason: 'clearing X_v2 must not touch class X',
+        );
+        await ParseObjectOffline.clearLocalCacheForClass('X');
+      });
+
+      test('an existing _v2 cache is moved to the new key', () async {
+        final store = ParseCoreData().getStore();
+        const base = 'offline_cache_$testClassName';
+        await store.setString(
+          '${base}_v2',
+          '{"old1":"{\\"className\\":\\"$testClassName\\",'
+              '\\"objectId\\":\\"old1\\",\\"name\\":\\"Legacy\\"}"}',
+        );
+
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'old1',
+        );
+        expect(loaded, isNotNull);
+        expect(loaded!.get<String>('name'), equals('Legacy'));
+
+        // Moved once, not read from the old key forever.
+        expect(await store.getString('$base:v2'), isNotNull);
+        expect(await store.getString('${base}_v2'), isNull);
+      });
+    });
+
     group('updateInLocalCache encoding', () {
       test('encodes raw values into Parse wire format', () async {
         final when = DateTime.utc(2026, 8, 10, 12, 30);
@@ -403,7 +446,7 @@ void main() {
 
         // ...and the legacy key is gone, so it migrates exactly once.
         expect(await store.getStringList(legacyKey), isNull);
-        expect(await store.getString('${legacyKey}_v2'), isNotNull);
+        expect(await store.getString('$legacyKey:v2'), isNotNull);
       });
     });
 
@@ -531,7 +574,7 @@ void main() {
         )..objectId = 'plain').saveToLocalCache();
         final store = ParseCoreData().getStore();
         expect(
-          await store.getString('offline_cache_${testClassName}_v2'),
+          await store.getString('offline_cache_$testClassName:v2'),
           isNotNull,
         );
       });

--- a/packages/dart/test/src/objects/parse_offline_object_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_object_test.dart
@@ -342,6 +342,38 @@ void main() {
       });
     });
 
+    group('updateInLocalCache encoding', () {
+      test('encodes raw values into Parse wire format', () async {
+        final when = DateTime.utc(2026, 8, 10, 12, 30);
+        final obj = ParseObject(testClassName)
+          ..objectId = 'encode1'
+          ..set('name', 'before');
+        await obj.saveToLocalCache();
+
+        // Cached entries hold what toJson(full: true) produces. A raw DateTime
+        // or ParseGeoPoint merged in as-is would not survive the round trip.
+        final updated = await obj.updateInLocalCache({
+          'name': 'after',
+          'when': when,
+          'where': ParseGeoPoint(latitude: 1.5, longitude: -2.5),
+        });
+        expect(updated, isTrue);
+
+        final loaded = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'encode1',
+        );
+        expect(loaded, isNotNull);
+        expect(loaded!.get<String>('name'), equals('after'));
+        // Decodes back as real Parse types, the same as a server response.
+        expect(loaded.get<DateTime>('when'), equals(when));
+        final geo = loaded.get<ParseGeoPoint>('where');
+        expect(geo, isNotNull);
+        expect(geo!.latitude, equals(1.5));
+        expect(geo.longitude, equals(-2.5));
+      });
+    });
+
     group('legacy format migration', () {
       test('migrates a List<String> cache and drops the legacy key', () async {
         // Arrange: seed the pre-map format directly under the legacy key.
@@ -502,6 +534,43 @@ void main() {
           await store.getString('offline_cache_${testClassName}_v2'),
           isNotNull,
         );
+      });
+
+      test(
+        'namespace and class name cannot be confused for one another',
+        () async {
+          // Joining with '_' was ambiguous: 'a_b' + 'c' and 'a' + 'b_c' both
+          // produced offline_cache_a_b_c. Parse class names really do contain
+          // underscores (_User, _Installation), so this collided in practice.
+          ParseObjectOffline.cacheNamespace = 'a_b';
+          await (ParseObject('c')..objectId = 'fromAB').saveToLocalCache();
+
+          ParseObjectOffline.cacheNamespace = 'a';
+          expect(
+            await ParseObjectOffline.loadFromLocalCache('b_c', 'fromAB'),
+            isNull,
+            reason: 'namespace a / class b_c must not see a_b / class c',
+          );
+          expect(
+            await ParseObjectOffline.loadAllFromLocalCache('b_c'),
+            isEmpty,
+          );
+
+          await ParseObjectOffline.clearLocalCacheForClass('b_c');
+          ParseObjectOffline.cacheNamespace = 'a_b';
+          await ParseObjectOffline.clearLocalCacheForClass('c');
+        },
+      );
+
+      test('a namespace with odd characters still round-trips', () async {
+        ParseObjectOffline.cacheNamespace = 'user:with/odd%chars';
+        await (ParseObject(testClassName)..objectId = 'odd').saveToLocalCache();
+        final back = await ParseObjectOffline.loadFromLocalCache(
+          testClassName,
+          'odd',
+        );
+        expect(back, isNotNull);
+        await ParseObjectOffline.clearLocalCacheForClass(testClassName);
       });
     });
   });

--- a/packages/dart/test/src/objects/parse_offline_sync_test.dart
+++ b/packages/dart/test/src/objects/parse_offline_sync_test.dart
@@ -1,0 +1,125 @@
+import 'package:universal_io/io.dart';
+
+import 'package:mockito/mockito.dart';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+import 'package:test/test.dart';
+
+import '../../parse_query_test.mocks.dart';
+
+/// Sync needs Parse initialised with a client we control, so it lives in its
+/// own file — `dart test` runs each file in a separate isolate, and Parse is a
+/// singleton that only initialises once.
+void main() {
+  const className = 'SyncTestClass';
+  late MockParseClient client;
+
+  setUpAll(() async {
+    client = MockParseClient();
+    await Parse().initialize(
+      'appId',
+      'https://example.com',
+      debug: false,
+      fileDirectory: 'someDirectory',
+      appName: 'appName',
+      appPackageName: 'somePackageName',
+      appVersion: 'someAppVersion',
+      clientCreator:
+          ({required bool sendSessionId, SecurityContext? securityContext}) =>
+              client,
+    );
+  });
+
+  setUp(() async {
+    reset(client);
+    await ParseObjectOffline.clearLocalCacheForClass(className);
+  });
+
+  tearDown(() async {
+    await ParseObjectOffline.clearLocalCacheForClass(className);
+  });
+
+  group('syncLocalCacheWithServer', () {
+    test('actually issues an update for each cached object', () async {
+      // A cache-loaded object is rebuilt from JSON. If it is rebuilt with
+      // `fromJson`, nothing is registered as an unsaved change, so `save()`
+      // sees `_isDirty(false) == false`, never calls `update()`, and still
+      // returns success from `_saveChildren`. Sync would then report every
+      // object as synced while sending nothing at all.
+      await (ParseObject(className)
+            ..objectId = 'sync1'
+            ..set('name', 'edited offline'))
+          .saveToLocalCache();
+
+      when(
+        client.put(any, data: anyNamed('data'), options: anyNamed('options')),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 200,
+          data: '{"updatedAt":"2026-08-10T12:00:00.000Z"}',
+        ),
+      );
+
+      final result = await ParseObjectOffline.syncLocalCacheWithServer(
+        className,
+      );
+
+      // The request must have gone out...
+      final verification = verify(
+        client.put(
+          captureAny,
+          data: captureAnyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      );
+      verification.called(1);
+      final String path = verification.captured[0] as String;
+      final String body = verification.captured[1] as String;
+      expect(path, contains('sync1'));
+      expect(body, contains('edited offline'));
+
+      // ...and only then is it reported as synced.
+      expect(result.synced, equals(1));
+      expect(result.hasFailures, isFalse);
+    });
+
+    test('reports a failed save instead of counting it as synced', () async {
+      await (ParseObject(className)
+            ..objectId = 'sync2'
+            ..set('name', 'will fail'))
+          .saveToLocalCache();
+
+      when(
+        client.put(any, data: anyNamed('data'), options: anyNamed('options')),
+      ).thenAnswer(
+        (_) async => ParseNetworkResponse(
+          statusCode: 400,
+          data: '{"code":101,"error":"Object not found"}',
+        ),
+      );
+
+      final result = await ParseObjectOffline.syncLocalCacheWithServer(
+        className,
+      );
+
+      expect(result.synced, equals(0));
+      expect(result.hasFailures, isTrue);
+      expect(result.failures, hasLength(1));
+      expect(result.failures.first.object.objectId, equals('sync2'));
+    });
+
+    test('shouldSync skips without sending', () async {
+      await (ParseObject(className)..objectId = 'sync3').saveToLocalCache();
+
+      final result = await ParseObjectOffline.syncLocalCacheWithServer(
+        className,
+        shouldSync: (_) => false,
+      );
+
+      verifyNever(
+        client.put(any, data: anyNamed('data'), options: anyNamed('options')),
+      );
+      expect(result.skipped, equals(1));
+      expect(result.synced, equals(0));
+    });
+  });
+}

--- a/packages/dart/test/src/storage/core_store_test.dart
+++ b/packages/dart/test/src/storage/core_store_test.dart
@@ -1,0 +1,199 @@
+import 'package:test/test.dart';
+import 'package:parse_server_sdk/parse_server_sdk.dart';
+
+void main() {
+  late CoreStoreMemoryImp store;
+
+  setUp(() async {
+    store = CoreStoreMemoryImp();
+    await store.clear();
+  });
+
+  group('CoreStore getStringList', () {
+    test('should return null when key does not exist', () async {
+      final result = await store.getStringList('nonexistent_key');
+      expect(result, isNull);
+    });
+
+    test('should return List<String> when stored as List<String>', () async {
+      final testList = ['item1', 'item2', 'item3'];
+      await store.setStringList('test_key', testList);
+
+      final result = await store.getStringList('test_key');
+
+      expect(result, isNotNull);
+      expect(result, isA<List<String>>());
+      expect(result, equals(testList));
+    });
+
+    test('should return empty list when stored empty list', () async {
+      final testList = <String>[];
+      await store.setStringList('empty_key', testList);
+
+      final result = await store.getStringList('empty_key');
+
+      expect(result, isNotNull);
+      expect(result, isEmpty);
+    });
+
+    test('should handle list with special characters', () async {
+      final testList = [
+        'item with spaces',
+        'item\nwith\nnewlines',
+        'item,with,commas',
+        '{"json": "object"}',
+      ];
+      await store.setStringList('special_key', testList);
+
+      final result = await store.getStringList('special_key');
+
+      expect(result, isNotNull);
+      expect(result, equals(testList));
+    });
+
+    test('should handle list with empty strings', () async {
+      final testList = ['', 'non-empty', ''];
+      await store.setStringList('empty_strings_key', testList);
+
+      final result = await store.getStringList('empty_strings_key');
+
+      expect(result, isNotNull);
+      expect(result, equals(testList));
+    });
+
+    test('should handle list with unicode characters', () async {
+      final testList = ['emoji 🎉', '日本語', 'العربية', 'מחרוזת'];
+      await store.setStringList('unicode_key', testList);
+
+      final result = await store.getStringList('unicode_key');
+
+      expect(result, isNotNull);
+      expect(result, equals(testList));
+    });
+
+    test('should overwrite existing list', () async {
+      final firstList = ['a', 'b', 'c'];
+      final secondList = ['x', 'y', 'z'];
+
+      await store.setStringList('overwrite_key', firstList);
+      await store.setStringList('overwrite_key', secondList);
+
+      final result = await store.getStringList('overwrite_key');
+
+      expect(result, equals(secondList));
+    });
+
+    test('should handle very long list', () async {
+      final longList = List.generate(1000, (index) => 'item_$index');
+      await store.setStringList('long_list_key', longList);
+
+      final result = await store.getStringList('long_list_key');
+
+      expect(result, isNotNull);
+      expect(result?.length, 1000);
+      expect(result?.first, 'item_0');
+      expect(result?.last, 'item_999');
+    });
+
+    test('should return null for non-list values', () async {
+      // Store a string value
+      await store.setString('string_key', 'just a string');
+
+      // getStringList should return null for non-list values
+      final result = await store.getStringList('string_key');
+
+      // This tests the improved getStringList handling
+      // It should handle non-list types gracefully by returning null
+      expect(result, isNull);
+    });
+  });
+
+  group('CoreStore basic operations', () {
+    test('should store and retrieve string', () async {
+      await store.setString('string_test', 'hello world');
+      final result = await store.getString('string_test');
+      expect(result, 'hello world');
+    });
+
+    test('should store and retrieve int', () async {
+      await store.setInt('int_test', 42);
+      final result = await store.getInt('int_test');
+      expect(result, 42);
+    });
+
+    test('should store and retrieve double', () async {
+      await store.setDouble('double_test', 3.14159);
+      final result = await store.getDouble('double_test');
+      expect(result, closeTo(3.14159, 0.0001));
+    });
+
+    test('should store and retrieve bool', () async {
+      await store.setBool('bool_test', true);
+      final result = await store.getBool('bool_test');
+      expect(result, true);
+    });
+
+    test('should check if key exists', () async {
+      await store.setString('exists_key', 'value');
+
+      final exists = await store.containsKey('exists_key');
+      final notExists = await store.containsKey('not_exists_key');
+
+      expect(exists, isTrue);
+      expect(notExists, isFalse);
+    });
+
+    test('should remove key', () async {
+      await store.setString('remove_key', 'to be removed');
+      await store.remove('remove_key');
+
+      final exists = await store.containsKey('remove_key');
+      expect(exists, isFalse);
+    });
+
+    test('should clear all keys', () async {
+      await store.setString('key1', 'value1');
+      await store.setString('key2', 'value2');
+
+      await store.clear();
+
+      final exists1 = await store.containsKey('key1');
+      final exists2 = await store.containsKey('key2');
+
+      expect(exists1, isFalse);
+      expect(exists2, isFalse);
+    });
+  });
+
+  group('CoreStore edge cases', () {
+    test('should handle null returns gracefully', () async {
+      final stringResult = await store.getString('missing');
+      final intResult = await store.getInt('missing');
+      final doubleResult = await store.getDouble('missing');
+      final boolResult = await store.getBool('missing');
+      final listResult = await store.getStringList('missing');
+
+      expect(stringResult, isNull);
+      expect(intResult, isNull);
+      expect(doubleResult, isNull);
+      expect(boolResult, isNull);
+      expect(listResult, isNull);
+    });
+
+    test('should handle special key names', () async {
+      const specialKeys = [
+        'key.with.dots',
+        'key-with-dashes',
+        'key_with_underscores',
+        'key/with/slashes',
+        'key:with:colons',
+      ];
+
+      for (final key in specialKeys) {
+        await store.setString(key, 'value for $key');
+        final result = await store.getString(key);
+        expect(result, 'value for $key', reason: 'Failed for key: $key');
+      }
+    });
+  });
+}

--- a/packages/dart/test/src/storage/core_store_test.dart
+++ b/packages/dart/test/src/storage/core_store_test.dart
@@ -1,3 +1,4 @@
+import 'package:sembast/sembast_memory.dart';
 import 'package:test/test.dart';
 import 'package:parse_server_sdk/parse_server_sdk.dart';
 
@@ -194,6 +195,55 @@ void main() {
         final result = await store.getString(key);
         expect(result, 'value for $key', reason: 'Failed for key: $key');
       }
+    });
+  });
+
+  group('CoreStoreSembastImp getStringList', () {
+    // The sembast implementation has its own decode path: a value that has
+    // been through the database comes back as List<dynamic>, which used to
+    // throw a CastError instead of returning the list.
+    late CoreStoreSembastImp sembastStore;
+
+    setUpAll(() async {
+      sembastStore = await CoreStoreSembastImp.getInstance(
+        'core_store_test.db',
+        factory: databaseFactoryMemory,
+        password: 'core_store_test',
+      );
+    });
+
+    setUp(() async {
+      await sembastStore.clear();
+    });
+
+    test('returns a usable List<String> for a stored list', () async {
+      const testList = ['alpha', 'beta', 'gamma'];
+      await sembastStore.setStringList('sembast_key', testList);
+
+      final result = await sembastStore.getStringList('sembast_key');
+
+      expect(result, isNotNull);
+      expect(result, isA<List<String>>());
+      expect(result, equals(testList));
+      // Must survive being handed to List<String>-typed code.
+      final List<String> asTyped = result!;
+      expect(asTyped.first, equals('alpha'));
+    });
+
+    test('returns null for a missing key', () async {
+      expect(await sembastStore.getStringList('no_such_key'), isNull);
+    });
+
+    test('handles an empty list', () async {
+      await sembastStore.setStringList('empty_key', <String>[]);
+      final result = await sembastStore.getStringList('empty_key');
+      expect(result, isNotNull);
+      expect(result, isEmpty);
+    });
+
+    test('returns null when the stored value is not a list', () async {
+      await sembastStore.setString('scalar_key', 'just a string');
+      expect(await sembastStore.getStringList('scalar_key'), isNull);
     });
   });
 }


### PR DESCRIPTION
## Pull Request

This is the Dart half of #1101, resubmitted as a self-contained PR. See [Background](#background) for why it was split.

## Issue

Closes: #1091 (partially — see note below), and fixes several defects found while running the SDK offline in production. No existing issue covers the LiveQuery, serialization or CoreStore bugs; happy to open individual issues if you'd prefer them tracked separately.

## Approach

Five bug fixes and two additive APIs, all confined to `packages/dart`. Every one of these was found by running the SDK in a production Flutter app under real network loss, not by inspection.

### Fixes

**1. LiveQuery subscriptions lost on reconnect and duplicated on resubscribe** (`parse_live_query.dart`)

Three related defects:

- `subscribe()` waited only for a raw socket, then sent the subscribe immediately. An open socket is not the same as an acknowledged LiveQuery `connect` handshake, so an early subscribe was answered with `Can not find this client`. Worse, `_subscribeLiveQuery` had already flipped `_enabled`, so the `connected` handler later skipped it and the subscription stayed permanently unregistered. Subscriptions are now always registered locally but only sent once a `connected` op arrives.
- On reconnect, the `connected` handler re-sent every known subscription without clearing `_enabled`, so the guard inside `_subscribeLiveQuery` skipped all of them. A fresh socket means the server has no record of any prior subscribe, so `_enabled` is now reset before re-sending.
- `unsubscribe()` kept both the server message *and* the local state drop inside the `channel != null` guard. Unsubscribing while disconnected (app backgrounded, socket dropped) was therefore a silent no-op: the entry survived in `_requestSubscription` and was resurrected on reconnect. Callers that cancel-and-resubscribe accumulated one extra subscription per cycle, and every event then invoked their handler once per accumulation. Notifying the server is now best-effort; dropping local state is unconditional.

**2. Stack overflow in `_canbeSerialized` when an object holds a null field** (`parse_object.dart`)

The method used `value == null` to detect its own entry call, making an explicit null field indistinguishable from "no argument passed". Recursing into such a field re-entered the whole-object branch, called `_getObjectData()` again, and looped until the stack blew.

Reachable from `saveEventually()` via `submitSaveEventually -> _saveChildren -> _canbeSerialized`. An Installation or analytics save carrying a null field on a cold launch with no network was enough to crash the app. Fixed with a private sentinel for the unset case.

**3. `CoreStore.getStringList` throws `CastError` on lists read back from disk** (`core_store_memory.dart`, `core_store_sem_impl.dart`)

Both implementations returned the stored value directly as `List<String>`. Anything that round-tripped through JSON comes back as `List<dynamic>`, so reading a previously persisted list threw `type 'List<dynamic>' is not a subtype of type 'List<String>?'` instead of returning it. Values are now coerced element-wise.

**4. `ParseLiveList` crashes when a query `include` names an array of pointers** (`parse_live_list.dart`)

The include/subscribe machinery derives its watch list from the query's `include`, which may legitimately name an array of pointers (`likeUsers`, `viewUsers`, …) or a relation. That machinery handles one object at a time and reached the field via `get<ParseObject>`, whose unguarded cast threw `type 'List<dynamic>' is not a subtype of type 'ParseObject?'` on every list update. Because the throw happened inside an async callback it surfaced as an unhandled error and silently killed include-loading and sub-item subscriptions for that row. Non-pointer includes are now skipped rather than crashing.

### Additions

**5. `ParseObjectOffline` extension** (`parse_offline_object.dart`, new)

A first-class offline cache built on the existing `CoreStore`, so apps can read and write Parse objects with no network.

| Kind | Methods |
|---|---|
| Instance | `saveToLocalCache`, `removeFromLocalCache`, `updateInLocalCache` |
| Static | `loadFromLocalCache`, `loadAllFromLocalCache`, `saveAllToLocalCache`, `getAllObjectIdsInLocalCache`, `existsInLocalCache`, `clearLocalCacheForClass`, `syncLocalCacheWithServer` |

Design notes:

- Entries are stored as a single JSON map keyed by `objectId`, making lookup and existence checks O(1) rather than scanning every row to compare ids. An earlier list-shaped format is migrated transparently on first read.
- `loadAllFromLocalCache` takes an optional `where` predicate, since the store holds one bucket per class and callers often want a subset (e.g. the messages of one conversation) without decoding the rest.
- Batch saves encode each object independently, so one unserialisable value cannot abort the whole batch and silently drop every other item.
- All logging goes through `isDebugEnabled()`, matching `LiveQueryClient`.

**6. `isOptimistic` on `ParseLiveListElementSnapshot`**

Additive, defaults to `false`. Lets a `childBuilder` distinguish a caller-supplied pending item from a server-confirmed one. Consumed by the Flutter follow-up described below.

## Background

<a name="background"></a>This work started as #1101, which grew to 9,852 lines across three unrelated areas and could not pass CI: the Flutter half calls Dart APIs introduced in the same PR, so it only resolved via a `dependency_overrides`, and the branch had drifted far enough behind `master` to collide with #1103 (REST retry) and #1091 (ethernet connectivity).

Splitting on the package boundary fixes all of that. This PR:

- touches only `packages/dart`, so it needs no dependency override and can be released on its own;
- is rebased on current `master`, so #1103 and #1091 are untouched;
- is 969 added lines across 9 files, in 7 reviewable commits, rather than 121 commits.

The Flutter widgets (`ParseLiveSliverListWidget`, `ParseLiveSliverGridWidget`, `ParseLiveListPageView`, offline mode and optimistic items on the existing list and grid) and the analytics subsystem will follow as separate PRs once this package is released. #1101 will be closed in favour of this series.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)

544 new lines of tests across `parse_offline_object_test.dart` (the full extension surface, including format migration and corrupt-entry handling) and `core_store_test.dart` (both `CoreStore` implementations). Full suite: **240 passing**, `dart analyze --fatal-infos` clean, `dart format` clean, `dart pub publish --dry-run` reports 0 warnings.

Public API is documented with dartdoc comments; each fix carries a comment explaining the failure mode so it is not reintroduced.

### A note on #1091

The ethernet fix in #1091 is untouched here. The earlier #1101 branch predated it and effectively reverted it; that regression does not exist in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline caching for Parse objects, including batch operations, local queries, cache management, namespace isolation, legacy cache migration, and optional server synchronization with detailed results.
  - Improved LiveQuery subscription handling during handshakes and reconnections.
  - Added optimistic-state tracking for live list items.

- **Bug Fixes**
  - Prevented recursive serialization errors when saving offline objects with null fields.
  - Improved stored list and array-valued include handling.
  - Ensured local subscriptions are properly removed when disconnected.

- **Tests**
  - Added comprehensive coverage for offline caching, synchronization, and local storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->